### PR TITLE
Do not use hardcoded networks directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Finally, the classification application needs the imagent models in the current 
 ```
 $ ls 
 classify  images  networks
-$ ./classify images/banana_0.jpg 1
+$ VACCEL_IMAGENET_NETWORKS=$(pwd) ./classify images/banana_0.jpg 1
 Initialized session with id: 1
 Image size: 79281B
 classification tags: 99.902% banana


### PR DESCRIPTION
The imagenet function we were using to load the model was assuming that
the networks were located in the "networks" directory of the CWD of the
application. This is very restrictive and difficult to work with. This
commit changes the functionality to look for networks in (a) a path
defined by an environment variable: `VACCEL_IMAGENET_NETWORKS` or (b) a
default path: `/usr/local/share/imagenet-models/networks`.

Signed-off-by: Babis Chalios <mail@bchalios.io>