### PR TITLE
WiP: Google Coral EdgeTPU classification plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ project(vaccelrt
 option(BUILD_PLUGIN_VIRTIO "Build the VirtIO plugin" OFF)
 option(BUILD_PLUGIN_JETSON "Build the Jetson plugin" OFF)
 option(BUILD_PLUGIN_VSOCK "Build thev vsock plugin" OFF)
+option(BUILD_PLUGIN_CORAL "Build the Google Coral plugin" OFF)
 option(BUILD_PLUGIN_NOOP "Build the no-op debugging plugin" OFF)
 option(BUILD_EXAMPLES "Build the examples" OFF)
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -6,6 +6,10 @@ if (BUILD_PLUGIN_JETSON)
 	add_subdirectory(jetson_inference)
 endif(BUILD_PLUGIN_JETSON)
 
+if (BUILD_PLUGIN_CORAL)
+	add_subdirectory(google_coral)
+endif(BUILD_PLUGIN_CORAL)
+
 if (BUILD_PLUGIN_VIRTIO)
 	add_subdirectory(virtio)
 endif(BUILD_PLUGIN_VIRTIO)

--- a/plugins/google_coral/CMakeLists.txt
+++ b/plugins/google_coral/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(CORAL_LIB /root/aarch64/examples)
+link_directories(${CORAL_LIB})
+
+set(include_dirs ${CMAKE_SOURCE_DIR}/src)
+message("Include directories: ${include_dirs}")
+set(SOURCES
+    operations.cpp
+    vaccel.cpp
+    ${include_dirs}/vaccel.h
+    ${include_dirs}/plugin.h)
+
+# expose rpath for libraries when installing
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+add_library(vaccel-coral SHARED ${SOURCES})
+target_include_directories(vaccel-coral PRIVATE ${include_dirs})
+target_link_libraries(vaccel-coral PRIVATE classify)
+
+# Setup make install
+install(TARGETS vaccel-coral DESTINATION "${lib_path}")

--- a/plugins/google_coral/operations.cpp
+++ b/plugins/google_coral/operations.cpp
@@ -1,0 +1,49 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "vaccel.h"
+
+extern "C" int coral_classify(char* model_path, char* labels_path, void *img, float thres, char** out_text, size_t *out_len);
+
+using namespace std;
+
+#define IMAGENET_NETWORKS_DEFAULT_PATH "/usr/local/share/imagenet-models/networks"
+#define IMAGENET_NETWORKS_ENVVAR "VACCEL_IMAGENET_NETWORKS"
+
+/* Check if a path exists and is a directory */
+static bool directory_exists(const char *path)
+{
+	struct stat s;
+	return (!stat(path, &s) && (s.st_mode & S_IFDIR));
+}
+
+static const char *find_imagenet_models_path(void)
+{
+	/* Check first the environment variable */
+	char *networks = getenv(IMAGENET_NETWORKS_ENVVAR);
+	if (networks && directory_exists(networks))
+		return networks;
+
+	if (directory_exists(IMAGENET_NETWORKS_DEFAULT_PATH))
+		return IMAGENET_NETWORKS_DEFAULT_PATH;
+
+	return NULL;
+}
+
+int coral_image_classification(struct vaccel_session *sess, void *img,
+		char *out_text, char *out_imgname,
+		size_t len_img, size_t len_out_text, size_t len_out_imgname)
+{
+
+	char *out_local_text;
+	coral_classify("mobilenet_v1_1.0_224_quant_edgetpu.tflite", "imagenet_labels.txt", img, 0.0001, &out_local_text, &len_out_text);
+	snprintf(out_text, len_out_text + 1, "%s", out_local_text);
+
+
+	return VACCEL_OK;
+}

--- a/plugins/google_coral/operations.h
+++ b/plugins/google_coral/operations.h
@@ -1,0 +1,16 @@
+#ifndef __VACCEL_JETSON_OPERATIONS_H__
+#define __VACCEL_JETSON_OPERATIONS_H__
+
+#include <stddef.h>
+
+int coral_image_classification(struct vaccel_session *sess, void *img,
+		char *out_text, char *out_imgname,
+		size_t len_img, size_t len_out_text, size_t len_out_imgname);
+int coral_image_detect(struct vaccel_session *sess, void *img,
+		char *out_text, char *out_imgname,
+		size_t len_img, size_t len_out_text, size_t len_out_imgname);
+int coral_image_segment(struct vaccel_session *sess, void *img,
+		char *out_text, char *out_imgname,
+		size_t len_img, size_t len_out_text, size_t len_out_imgname);
+
+#endif /* __VACCEL_JETSON_OPERATIONS_H__ */

--- a/plugins/google_coral/vaccel.cpp
+++ b/plugins/google_coral/vaccel.cpp
@@ -1,0 +1,29 @@
+#include <vaccel.h>
+#include <plugin.h>
+#include <vaccel_ops.h>
+#include "operations.h"
+
+struct vaccel_op ops[] = {
+	VACCEL_OP_INIT(ops[0], VACCEL_IMG_CLASS, (void *)coral_image_classification),
+};
+
+int coral_init(void)
+{
+	int ret = register_plugin_functions(ops, sizeof(ops) / sizeof(ops[0]));
+	if (!ret)
+		return ret;
+
+	return VACCEL_OK;
+}
+
+int coral_finalize(void)
+{
+	return VACCEL_OK;
+}
+
+VACCEL_MODULE(
+	.name = "google_coral",
+	.version = "0.1",
+	.init = coral_init,
+	.fini = coral_finalize,
+)


### PR DESCRIPTION
This is a rough first attempt to support inference on the Google Coral
TPU.

For now, only image classification is supported, on the expected image
size (224x224x24) & format (BMP) using the mobilenet_v1_1.0_224 edgetpu
tflite model.