### PR TITLE
Add the generic operation.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        image: nubificus/vaccel-deps:${{ steps.install-deps.outputs.tag }}
+        image: nubificus/vaccel-deps:${{ matrix.archconfig }}
         options: -v ${{ github.workspace }}:/work -e BUILD_TYPE=${{ matrix.build_type }} -e ARCHCONFIG=${{ matrix.archconfig }} ${{ steps.install-deps.outputs.docker_options }}
         run: |
           cargo --version

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,8 +1,17 @@
 set(include_dirs ${CMAKE_SOURCE_DIR}/src)
 
 add_executable(classify classification.c)
+add_executable(noop noop.c)
+add_executable(genop genop.c)
+
 target_include_directories(classify PRIVATE ${include_dirs})
 target_link_libraries(classify PRIVATE vaccel dl)
+
+target_include_directories(noop PRIVATE ${include_dirs})
+target_link_libraries(noop PRIVATE vaccel dl)
+
+target_include_directories(genop PRIVATE ${include_dirs})
+target_link_libraries(genop PRIVATE vaccel dl)
 
 # Install the examples
 install(TARGETS classify DESTINATION "${bin_path}")

--- a/examples/genop.c
+++ b/examples/genop.c
@@ -1,0 +1,37 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <vaccel.h>
+#include <vaccel_ops.h>
+
+int main()
+{
+	int ret;
+	struct vaccel_session sess;
+	size_t len = 10;
+	char *ptr = malloc(len);
+	char *out_ptr = malloc(len);
+
+	ret = vaccel_sess_init(&sess, 0);
+	if (ret != VACCEL_OK) {
+		fprintf(stderr, "Could not initialize session\n");
+		return 1;
+	}
+
+	printf("Initialized session with id: %u\n", sess.session_id);
+
+	ret = vaccel_genop(&sess, out_ptr, ptr, len, len);
+	if (ret) {
+		fprintf(stderr, "Could not run op: %d\n", ret);
+		goto close_session;
+	}
+
+close_session:
+	if (vaccel_sess_free(&sess) != VACCEL_OK) {
+		fprintf(stderr, "Could not clear session\n");
+		return 1;
+	}
+
+	return ret;
+}

--- a/examples/noop.c
+++ b/examples/noop.c
@@ -1,0 +1,43 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <vaccel.h>
+#include <vaccel_ops.h>
+
+int main()
+{
+	int ret;
+	struct vaccel_session sess;
+
+	ret = vaccel_sess_init(&sess, 0);
+	if (ret != VACCEL_OK) {
+		fprintf(stderr, "Could not initialize session\n");
+		return 1;
+	}
+
+	printf("Initialized session with id: %u\n", sess.session_id);
+
+	char A[] = "this is a sentence";
+	char B[] = "this is a another sentence";
+	size_t len = strlen(A) + strlen(B);
+	char *ptr = malloc (len);
+	memcpy(ptr, A, strlen(A));
+	memcpy(ptr+strlen(A),B,strlen(B));
+	char *out_ptr = malloc (len);
+	ret = vaccel_genop(&sess,out_ptr, ptr, len, len);
+	if (ret) {
+		fprintf(stderr, "Could not run op: %d\n", ret);
+		goto close_session;
+	}
+	printf("input%s\n", ptr);
+	printf("output %s\n", out_ptr);
+
+close_session:
+	if (vaccel_sess_free(&sess) != VACCEL_OK) {
+		fprintf(stderr, "Could not clear session\n");
+		return 1;
+	}
+
+	return ret;
+}

--- a/plugins/noop/vaccel.c
+++ b/plugins/noop/vaccel.c
@@ -1,17 +1,37 @@
 #include <stdio.h>
 #include <plugin.h>
 
+#include "log.h"
+
 static int noop(struct vaccel_session *session)
 {
-	fprintf(stdout, "Calling no-op for session %u", session->session_id);
+	vaccel_debug("Calling no-op for session %u", session->session_id);
 	return VACCEL_OK;
 }
 
-struct vaccel_op op = VACCEL_OP_INIT(op, VACCEL_NO_OP, noop);
+static int genop(struct vaccel_session *session, void *out_args, void *in_args,
+		size_t out_nargs, size_t in_nargs)
+{
+	int i = 0;
+	vaccel_debug("Calling do-op for session %u", session->session_id);
+
+	vaccel_debug("[noop] [genop] in_nargs: %d, out_nargs: %d\n", in_nargs, out_nargs);
+
+	return VACCEL_OK;
+}
+
+struct vaccel_op ops[] = {
+        VACCEL_OP_INIT(ops[0], VACCEL_NO_OP, noop),
+        VACCEL_OP_INIT(ops[1], VACCEL_BLAS_SGEMM, noop),
+        VACCEL_OP_INIT(ops[2], VACCEL_IMG_CLASS, noop),
+        VACCEL_OP_INIT(ops[3], VACCEL_IMG_DETEC, noop),
+        VACCEL_OP_INIT(ops[4], VACCEL_IMG_SEGME, noop),
+        VACCEL_OP_INIT(ops[5], VACCEL_GEN_OP, genop),
+};
 
 static int init(void)
 {
-	return register_plugin_function(&op);
+        return register_plugin_functions(ops, sizeof(ops) / sizeof(ops[0]));
 }
 
 static int fini(void)

--- a/plugins/virtio/ioctl.c
+++ b/plugins/virtio/ioctl.c
@@ -6,6 +6,8 @@
 
 #include <vaccel.h>
 
+#include "log.h"
+
 int dev_write(unsigned long req, void *data)
 {
 	int fd = open("/dev/accel", O_RDWR, 0);

--- a/plugins/virtio/operations.c
+++ b/plugins/virtio/operations.c
@@ -23,6 +23,29 @@ int virtio_noop(struct vaccel_session *sess)
 	return dev_write(VACCEL_DO_OP, &vsess);
 }
 
+int virtio_genop(struct vaccel_session *sess, void *out_args, 
+		void *in_args, size_t out_nargs, size_t in_nargs)
+{
+       unsigned int op_type = VACCEL_GEN_OP;
+       struct accel_session vsess = { 0 };
+       struct accel_arg args[4] = {
+               { sizeof(op_type), (char *)&op_type },
+               { in_nargs, (unsigned char *)in_args },
+               { out_nargs, (unsigned char *)out_args },
+       };
+
+       vsess.id = sess->session_id;
+       vsess.op.out_nr = 2;
+       vsess.op.out = &args[0];
+       vsess.op.in_nr = 1;
+       vsess.op.in = &args[2];
+
+       vaccel_debug("[virtio] session:%u Executing gen-op",
+                       sess->session_id);
+
+       return dev_write(VACCEL_DO_OP, &vsess);
+}
+
 int virtio_sgemm(struct vaccel_session *sess, uint32_t k, uint32_t m,
 		uint32_t n, size_t len_a, size_t len_b, size_t len_c,
 		float *a, float *b, float *c)

--- a/plugins/virtio/operations.h
+++ b/plugins/virtio/operations.h
@@ -21,5 +21,8 @@ int virtio_image_detection(struct vaccel_session *sess, void *img,
 int virtio_image_segmentation(struct vaccel_session *sess, void *img,
 		char *out_imgname, size_t len_img, size_t len_out_imgname);
 
+int virtio_genop(struct vaccel_session *sess, void *out_args, void *in_args,
+		size_t out_nargs, size_t in_nargs);
+
 
 #endif /* __VACCEL_VIRTIO_OPERATIONS_H__ */

--- a/plugins/virtio/vaccel.c
+++ b/plugins/virtio/vaccel.c
@@ -6,10 +6,11 @@
 
 struct vaccel_op ops[] = {
 	VACCEL_OP_INIT(ops[0], VACCEL_NO_OP, virtio_noop),
-	VACCEL_OP_INIT(ops[1], VACCEL_BLAS_SGEMM, virtio_sgemm),
+	VACCEL_OP_INIT(ops[1], VACCEL_BLAS_SGEMM, virtio_noop),
 	VACCEL_OP_INIT(ops[2], VACCEL_IMG_CLASS, virtio_image_classification),
 	VACCEL_OP_INIT(ops[3], VACCEL_IMG_DETEC, virtio_image_detection),
 	VACCEL_OP_INIT(ops[4], VACCEL_IMG_SEGME, virtio_image_segmentation),
+	VACCEL_OP_INIT(ops[5], VACCEL_GEN_OP, virtio_genop),
 };
 
 int virtio_init(void)

--- a/src/vaccel_ops.c
+++ b/src/vaccel_ops.c
@@ -10,6 +10,7 @@ typedef typeof(vaccel_sgemm) sgemm_t;
 typedef typeof(vaccel_image_classification) image_classification_t;
 typedef typeof(vaccel_image_detection) image_detection_t;
 typedef typeof(vaccel_image_segmentation) image_segmentation_t;
+typedef typeof(vaccel_genop) genop_t;
 
 int vaccel_noop(struct vaccel_session *sess)
 {
@@ -45,3 +46,21 @@ int vaccel_image_classification(struct vaccel_session *sess, const void *img,
 	return plugin_op(sess, img, out_text, out_imgname, len_img,
 			len_out_text, len_out_imgname);
 }
+
+int vaccel_genop(struct vaccel_session *sess, void *out_args, void *in_args, size_t out_nargs, size_t in_nargs)
+{
+	if (!sess)
+		return VACCEL_EINVAL;
+
+	vaccel_debug("session:%u Looking for plugin implementing generic op",
+			sess->session_id);
+
+	//Get implementation
+	genop_t *plugin_op = get_plugin_op(VACCEL_GEN_OP);
+	if (!plugin_op)
+		return VACCEL_ENOTSUP;
+
+	return plugin_op(sess, out_args, in_args, out_nargs, in_nargs);
+}
+
+

--- a/src/vaccel_ops.h
+++ b/src/vaccel_ops.h
@@ -9,7 +9,8 @@
 #define VACCEL_IMG_CLASS    2
 #define VACCEL_IMG_DETEC    3
 #define VACCEL_IMG_SEGME    4
-#define VACCEL_FUNCTIONS_NR 5
+#define VACCEL_GEN_OP	    5
+#define VACCEL_FUNCTIONS_NR 6
 
 static const char *vaccel_op_name[] = {
 	"noop",
@@ -17,6 +18,7 @@ static const char *vaccel_op_name[] = {
 	"image-classification",
 	"image-detection",
 	"image-segmentation",
+	"gen-op",
 };
 
 inline static const char *vaccel_op_type_str(uint8_t op_type)
@@ -28,6 +30,9 @@ struct vaccel_session;
 
 /* vaccel supported operations */
 int vaccel_noop(struct vaccel_session *sess);
+int vaccel_genop(struct vaccel_session *sess,
+		void *out_args, void *in_args, 
+		size_t out_nargs, size_t in_nargs);
 int vaccel_sgemm(struct vaccel_session *sess,
 		uint32_t k, uint32_t m, uint32_t n,
 		size_t len_a, size_t len_b, size_t len_c,


### PR DESCRIPTION
VACCEL_GEN_OP is a generic operation where the frontend has a
prototype of the form:

function(output, input, output_len, input_len);

in order to serve as a generic abstraction for any kind of
execution.

The form of input and output parameters is completely agnostic
to the framework. vAccel just forwards a call to a specific
function implemented as a plugin. The actual arguments are unpacked
in the plugin and packed in a small wrapper template in the
frontend (not included in this patchset). For clarity, the wrapper
template should be available as an example to help individuals port
their functions to vAccel.

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>