### PR TITLE
noop: Add debug info for all functions

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,4 +22,4 @@ target_include_directories(noop PRIVATE ${include_dirs})
 target_link_libraries(noop PRIVATE vaccel dl)
 
 # Install the examples
-install(TARGETS classify classify_generic DESTINATION "${bin_path}")
+install(TARGETS classify classify_generic noop exec exec_generic DESTINATION "${bin_path}")

--- a/plugins/noop/vaccel.c
+++ b/plugins/noop/vaccel.c
@@ -1,17 +1,71 @@
 #include <stdio.h>
 #include <plugin.h>
 
-static int noop(struct vaccel_session *session)
+static int noop_noop(struct vaccel_session *sess)
 {
-	fprintf(stdout, "Calling no-op for session %u", session->session_id);
+	fprintf(stdout, "[noop] Calling no-op for session %u\n",
+		sess->session_id);
 	return VACCEL_OK;
 }
 
-struct vaccel_op op = VACCEL_OP_INIT(op, VACCEL_NO_OP, noop);
+static int noop_sgemm(struct vaccel_session *sess, uint32_t k, uint32_t m,
+		      uint32_t n, size_t len_a, size_t len_b, size_t len_c,
+		      float *a, float *b, float *c)
+{
+	fprintf(stdout, "[noop] Calling sgemm for session %u\n",
+		sess->session_id);
+	return VACCEL_OK;
+}
+
+static int noop_img_class(struct vaccel_session *sess, const void *img,
+			  unsigned char *out_text, unsigned char *out_imgname,
+			  size_t len_img, size_t len_out_text,
+			  size_t len_out_imgname)
+{
+	fprintf(stdout, "[noop] Calling Image classification for session %u\n",
+		sess->session_id);
+	return VACCEL_OK;
+}
+
+static int noop_img_detect(struct vaccel_session *sess, const void *img,
+			   const unsigned char *out_imgname, size_t len_img,
+			   size_t len_out_imgname)
+{
+	fprintf(stdout, "[noop] Calling Image detection for session %u\n",
+		sess->session_id);
+	return VACCEL_OK;
+}
+
+static int noop_img_segme(struct vaccel_session *sess, const void *img,
+			  const unsigned char *out_imgname, size_t len_img,
+			  size_t len_out_imgname)
+{
+	fprintf(stdout, "[noop] Calling Image segmentation for session %u\n",
+		sess->session_id);
+	return VACCEL_OK;
+}
+
+static int noop_exec(struct vaccel_session *sess, const char *library,
+		     const char *fn_symbol, struct vaccel_arg *read,
+		     size_t nr_read, struct vaccel_arg *write, size_t nr_write)
+{
+	fprintf(stdout, "[noop] Calling exec for session %u\n",
+		sess->session_id);
+	return VACCEL_OK;
+}
+
+struct vaccel_op ops[] = {
+	VACCEL_OP_INIT(ops[0], VACCEL_NO_OP, noop_noop),
+	VACCEL_OP_INIT(ops[1], VACCEL_BLAS_SGEMM, noop_sgemm),
+	VACCEL_OP_INIT(ops[2], VACCEL_IMG_CLASS, noop_img_class),
+	VACCEL_OP_INIT(ops[3], VACCEL_IMG_DETEC, noop_img_detect),
+	VACCEL_OP_INIT(ops[4], VACCEL_IMG_SEGME, noop_img_segme),
+	VACCEL_OP_INIT(ops[5], VACCEL_EXEC, noop_exec),
+};
 
 static int init(void)
 {
-	return register_plugin_function(&op);
+	return register_plugin_functions(ops, sizeof(ops) / sizeof(ops[0]));
 }
 
 static int fini(void)

--- a/plugins/noop/vaccel.c
+++ b/plugins/noop/vaccel.c
@@ -1,10 +1,13 @@
 #include <stdio.h>
+#include <string.h>
+
 #include <plugin.h>
 
 static int noop_noop(struct vaccel_session *sess)
 {
 	fprintf(stdout, "[noop] Calling no-op for session %u\n",
 		sess->session_id);
+
 	return VACCEL_OK;
 }
 
@@ -14,6 +17,11 @@ static int noop_sgemm(struct vaccel_session *sess, uint32_t k, uint32_t m,
 {
 	fprintf(stdout, "[noop] Calling sgemm for session %u\n",
 		sess->session_id);
+
+	fprintf(stdout, "[noop] Dumping arguments for sgemm:\n");
+	fprintf(stdout, "[noop] k: %u m: %u n: %u\n", k, m, n);
+	fprintf(stdout, "[noop] len_a: %lu len_b: %lu len_c: %lu\n", len_a, len_b, len_c);
+	
 	return VACCEL_OK;
 }
 
@@ -24,6 +32,13 @@ static int noop_img_class(struct vaccel_session *sess, const void *img,
 {
 	fprintf(stdout, "[noop] Calling Image classification for session %u\n",
 		sess->session_id);
+
+	fprintf(stdout, "[noop] Dumping arguments for Image classification:\n");
+	fprintf(stdout, "[noop] len_img: %lu\n", len_img);
+	fprintf(stdout, "[noop] will return a dummy result\n");
+	sprintf(out_text, "This is a dummy classification tag!");
+	len_out_text = strlen("This is a dummy classification tag!");
+
 	return VACCEL_OK;
 }
 
@@ -33,6 +48,10 @@ static int noop_img_detect(struct vaccel_session *sess, const void *img,
 {
 	fprintf(stdout, "[noop] Calling Image detection for session %u\n",
 		sess->session_id);
+
+	fprintf(stdout, "[noop] Dumping arguments for Image detection:\n");
+	fprintf(stdout, "[noop] len_img: %lu\n", len_img);
+
 	return VACCEL_OK;
 }
 
@@ -42,6 +61,10 @@ static int noop_img_segme(struct vaccel_session *sess, const void *img,
 {
 	fprintf(stdout, "[noop] Calling Image segmentation for session %u\n",
 		sess->session_id);
+
+	fprintf(stdout, "[noop] Dumping arguments for Image segmentation:\n");
+	fprintf(stdout, "[noop] len_img: %lu\n", len_img);
+
 	return VACCEL_OK;
 }
 
@@ -51,6 +74,11 @@ static int noop_exec(struct vaccel_session *sess, const char *library,
 {
 	fprintf(stdout, "[noop] Calling exec for session %u\n",
 		sess->session_id);
+
+	fprintf(stdout, "[noop] Dumping arguments for exec:\n");
+	fprintf(stdout, "[noop] library: %s symbol: %s\n", library, fn_symbol);
+	fprintf(stdout, "[noop] nr_read: %lu nr_write: %lu\n", nr_read, nr_write);
+
 	return VACCEL_OK;
 }
 


### PR DESCRIPTION
Add dummy function in the noop plugin to dump arguments and more debug info. Also, when possible, return dummy values to verify the full path works correctly.