### PR TITLE
Polish examples, add all to install path

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,5 +21,10 @@ add_executable(noop noop.c)
 target_include_directories(noop PRIVATE ${include_dirs})
 target_link_libraries(noop PRIVATE vaccel dl)
 
+add_library(mytestlib SHARED mytestlib.c)
+target_compile_options(mytestlib PUBLIC -Wall -Wextra )
+set_target_properties(mytestlib PROPERTIES ENABLE_EXPORTS on)
+
 # Install the examples
 install(TARGETS classify classify_generic noop exec exec_generic DESTINATION "${bin_path}")
+install(TARGETS mytestlib DESTINATION "${lib_path}")

--- a/examples/exec.c
+++ b/examples/exec.c
@@ -14,10 +14,10 @@ int main(int argc, char *argv[])
 	int input;
 	char out_text[512];
 
-	if (argc < 2 ) {
-                fprintf(stderr, "You must specify the number of iterations\n");
-                return 1;
-        }
+	if (argc < 2) {
+		fprintf(stderr, "You must specify the number of iterations\n");
+		return 1;
+	}
 
 	ret = vaccel_sess_init(&sess, 0);
 	if (ret != VACCEL_OK) {
@@ -27,16 +27,18 @@ int main(int argc, char *argv[])
 
 	printf("Initialized session with id: %u\n", sess.session_id);
 
-	input = 10; /* some random input value */
+	input = 10;		/* some random input value */
 	struct vaccel_arg read[1] = {
-		{ .size = sizeof(input), .buf = &input }
+		{.size = sizeof(input),.buf = &input}
 	};
 	struct vaccel_arg write[1] = {
-		{ .size = sizeof(out_text), .buf = out_text },
+		{.size = sizeof(out_text),.buf = out_text},
 	};
 
 	for (int i = 0; i < atoi(argv[1]); ++i) {
-		ret = vaccel_exec(&sess, "mytestlib.so", "mytestfunc", read, 1, write, 1);
+		ret =
+		    vaccel_exec(&sess, "/usr/local/lib/libmytestlib.so",
+				"mytestfunc", read, 1, write, 1);
 		if (ret) {
 			fprintf(stderr, "Could not run op: %d\n", ret);
 			goto close_session;
@@ -44,8 +46,7 @@ int main(int argc, char *argv[])
 	}
 	printf("output: %s\n", out_text);
 
-
-close_session:
+ close_session:
 	if (vaccel_sess_free(&sess) != VACCEL_OK) {
 		fprintf(stderr, "Could not clear session\n");
 		return 1;

--- a/examples/exec_generic.c
+++ b/examples/exec_generic.c
@@ -14,7 +14,7 @@ int main(int argc, char **argv)
 	struct vaccel_session sess;
 	char out_text[512];
 
-	if (argc < 2 ) {
+	if (argc < 2) {
 		fprintf(stderr, "You must specify the number of iterations\n");
 		return 1;
 	}
@@ -24,16 +24,16 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-
 	printf("Initialized session with id: %u\n", sess.session_id);
 
 	struct vaccel_arg read[3] = {
-		{ .size = sizeof(uint8_t), .buf = (void *)VACCEL_EXEC },
-		{ .size = strlen("mytestlib.so"), .buf = "mytestlib.so" },
-		{ .size = strlen("mytestfunc"), .buf = "mytestfunc" }
+		{.size = sizeof(uint8_t),.buf = (void *)VACCEL_EXEC},
+		{.size = strlen("/usr/local/lib/libmytestlib.so"),.buf =
+		 "mytestlib.so"},
+		{.size = strlen("mytestfunc"),.buf = "mytestfunc"}
 	};
 	struct vaccel_arg write[1] = {
-		{ .size = sizeof(out_text), .buf = out_text },
+		{.size = sizeof(out_text),.buf = out_text},
 	};
 
 	for (int i = 0; i < atoi(argv[1]); ++i) {
@@ -44,8 +44,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-
-close_session:
+ close_session:
 	if (vaccel_sess_free(&sess) != VACCEL_OK) {
 		fprintf(stderr, "Could not clear session\n");
 		return 1;

--- a/examples/mytestlib.c
+++ b/examples/mytestlib.c
@@ -1,0 +1,29 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+struct vaccel_arg {
+	uint32_t len;
+	void *buf;
+};
+
+/* We know we're getting only one read and only one write argument */
+
+int mytestfunc(struct vaccel_arg *input, size_t nr_in,
+	       struct vaccel_arg *output, size_t nr_out)
+{
+	int a = *(int *)input[0].buf;
+	assert(nr_in >= 1);
+	assert(nr_out >= 1);
+	printf("I got this input: %d\n", a);
+	sprintf(output[0].buf, "I got this input: %d\n", a);
+	output[0].len = strlen(output[0].buf);
+
+	return 0;
+}


### PR DESCRIPTION
Fix indentation on exec & exec_generic, add a test library
install it in /usr/local/lib (default lib path) and use it.

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>