### PR TITLE
change delim for VACCEL_BACKENDS from ';' to ':'

### DIFF
--- a/src/vaccel.c
+++ b/src/vaccel.c
@@ -60,15 +60,23 @@ close_dl:
 
 static int load_backend_plugins(char *plugins)
 {
-	char *plugin = strtok(plugins, ";");
+	char *plugin;
+
+	char *plugins_tmp = strdup(plugins);
+	if (!plugins_tmp)
+		return VACCEL_ENOMEM;
+
+	char *p = plugins_tmp;
+	plugin = strtok(p, ":");
 	while (plugin) {
 		int ret = load_backend_plugin(plugin);
 		if (ret != VACCEL_OK)
 			return ret;
 
-		plugin = strtok(NULL, ";");
+		plugin = strtok(NULL, ":");
 	}
-
+	
+	free(plugins_tmp);
 	return VACCEL_OK;
 }
 


### PR DESCRIPTION
; char is a bash special character (command separator), making it more difficult to export it in an env variable. Switch to : as delimeter for VACCEL_BACKENDS paths
Signed-off-by: Orestis Lagkas Nikolos <olagkasn@nubificus.co.uk>