### PR TITLE
Correct handling of file persisting and removing files

### DIFF
--- a/examples/tf_inference.c
+++ b/examples/tf_inference.c
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
 	ret = vaccel_sess_init(&vsess, 0);
 	if (ret) {
 		fprintf(stderr, "Could not initialize vAccel session\n");
-		exit(1);
+		goto destroy_resource;
 	}
 
 	printf("Initialized vAccel session %u\n", vsess.session_id);
@@ -101,5 +101,8 @@ unregister_resource:
 close_session:
 	vaccel_sess_free(&vsess);
 
-	return 0;
+destroy_resource:
+	vaccel_tf_saved_model_destroy(&model);
+
+	return ret;
 }

--- a/examples/tf_saved_model.c
+++ b/examples/tf_saved_model.c
@@ -18,7 +18,7 @@ static unsigned char *read_file(const char *path, size_t *len)
 
 	status = fstat(fd, &stat);
 	if (status < 0) {
-		perror("Coult not stat file");
+		perror("Could not stat file");
 		return NULL;
 	}
 
@@ -34,85 +34,197 @@ static unsigned char *read_file(const char *path, size_t *len)
 	return ptr;
 }
 
+static unsigned char *read_file_from_dir(
+	const char *dir,
+	const char *path,
+	size_t *len
+) {
+	char fpath[1024];
+
+	snprintf(fpath, 1024, "%s/%s", dir, path);
+	unsigned char *ptr = read_file(fpath, len);
+	if (!ptr)
+		vaccel_error("Could not mmap %s", fpath);
+
+	return ptr;
+}
+
+
+int create_session(struct vaccel_session *sess)
+{
+	int ret = vaccel_sess_init(sess, 0);
+	if (ret) {
+		vaccel_error("Could not initialize session");
+		return ret;
+	}
+
+	vaccel_info("New session: %u", sess->session_id);
+	return VACCEL_OK;
+}
+
+int destroy_session(struct vaccel_session *sess)
+{
+	vaccel_sess_free(sess);
+	return VACCEL_OK;
+}
+
+int create_from_path(const char *path)
+{
+	vaccel_info("Creating new SavedModel handle");
+	struct vaccel_tf_saved_model *model = vaccel_tf_saved_model_new();
+	if (!model) {
+		vaccel_error("Could not create model");
+		return VACCEL_ENOMEM;
+	}
+
+	vaccel_info("Setting path of the model");
+	int ret = vaccel_tf_saved_model_set_path(model, path);
+	if (ret) {
+		vaccel_error("Could not load saved model");
+		return ret;
+	}
+
+	vaccel_info("Registering model resource with vAccel");
+	ret = vaccel_tf_saved_model_register(model);
+	if (ret) {
+		vaccel_error("Could not create model resource");
+		return ret;
+	}
+
+	vaccel_id_t model_id = vaccel_tf_saved_model_id(model);
+	vaccel_info("Registered new resource: %ld", model_id);
+
+	struct vaccel_session sess;
+	ret = create_session(&sess);
+	if (ret)
+		return ret;
+
+	vaccel_info("Registering model %ld with session %u", model_id,
+			sess.session_id);
+
+	ret = vaccel_sess_register(&sess, model->resource);
+	if (ret) {
+		vaccel_error("Could not register model to session");
+		return ret;
+	}
+
+	vaccel_info("Unregistering model %ld from session %u", model_id,
+			sess.session_id);
+
+	ret = vaccel_sess_unregister(&sess, model->resource);
+	if (ret) {
+		vaccel_error("Could not unregister model from session");
+		return ret;
+	}
+
+	vaccel_info("Destroying model %ld", model_id);
+	ret = vaccel_tf_saved_model_destroy(model);
+	if (ret) {
+		vaccel_error("Could not destroy model");
+		return ret;
+	}
+
+	vaccel_info("Destroying session %u", sess.session_id);
+	return destroy_session(&sess);
+}
+
+int create_from_in_mem(const char *path)
+{
+	vaccel_info("Creating new SavedModel handle");
+	struct vaccel_tf_saved_model *model = vaccel_tf_saved_model_new();
+	if (!model) {
+		vaccel_error("Could not create model");
+		return VACCEL_ENOMEM;
+	}
+
+	size_t len;
+	unsigned char *ptr = read_file_from_dir(path, "saved_model.pb", &len);
+	if (!ptr)
+		return VACCEL_ENOMEM;
+
+	int ret = vaccel_tf_saved_model_set_model(model, ptr, len);
+	if (ret) {
+		vaccel_error("Could not set pb file for model");
+		return ret;
+	}
+
+	ptr = read_file_from_dir(path, "variables/variables.index", &len);
+	if (!ptr)
+		return VACCEL_ENOMEM;
+
+	ret = vaccel_tf_saved_model_set_checkpoint(model, ptr, len);
+	if (ret) {
+		vaccel_error("Could not set checkpoint file for model");
+		return ret;
+	}
+
+	ptr = read_file_from_dir(path, "variables/variables.index", &len);
+	if (!ptr)
+		return VACCEL_ENOMEM;
+
+	ret = vaccel_tf_saved_model_set_var_index(model, ptr, len);
+	if (ret) {
+		vaccel_error("Could not set var index file for model");
+		return ret;
+	}
+
+	vaccel_info("Registering model resource with vAccel");
+	ret = vaccel_tf_saved_model_register(model);
+	if (ret) {
+		vaccel_error("Could not create model resource");
+		return ret;
+	}
+
+	vaccel_id_t model_id = vaccel_tf_saved_model_id(model);
+	vaccel_info("Registered new resource: %ld", model_id);
+
+
+	struct vaccel_session sess;
+	ret = create_session(&sess);
+	if (ret)
+		return ret;
+
+	vaccel_info("Registering model %ld with session %u", model_id,
+			sess.session_id);
+
+	ret = vaccel_sess_register(&sess, model->resource);
+	if (ret) {
+		vaccel_error("Could not register model to session");
+		return ret;
+	}
+
+	vaccel_info("Unregistering model %ld from session %u", model_id,
+			sess.session_id);
+
+	ret = vaccel_sess_unregister(&sess, model->resource);
+	if (ret) {
+		vaccel_error("Could not unregister model from session");
+		return ret;
+	}
+
+	vaccel_info("Destroying model %ld", model_id);
+	ret = vaccel_tf_saved_model_destroy(model);
+	if (ret) {
+		vaccel_error("Could not destroy model");
+		return ret;
+	}
+
+	vaccel_info("Destroying session %u", sess.session_id);
+	return destroy_session(&sess);}
+
+
 int main(int argc, char *argv[])
 {
 	if (argc != 2) {
-		fprintf(stderr, "usage: %s saved_model_path\n", argv[0]);
+		vaccel_info("usage: %s saved_model_path", argv[0]);
 		return 0;
 	}
 
-	struct vaccel_tf_saved_model *model1 = vaccel_tf_saved_model_new();
-	if (!model1) {
-		fprintf(stderr, "Could not create model\n");
-		return 1;
-	}
-
-	int ret = vaccel_tf_saved_model_set_path(model1, argv[1]);
-	if (ret) {
-		fprintf(stderr, "Could not load saved model\n");
+	vaccel_info("Testing SavedModel handling from path");
+	int ret = create_from_path(argv[1]);
+	if (ret)
 		return ret;
-	}
 
-	ret = vaccel_tf_saved_model_register(model1);
-	if (ret) {
-		fprintf(stderr, "Could not create model resource\n");
-		return ret;
-	}
-
-	struct vaccel_tf_saved_model *model2 = vaccel_tf_saved_model_new();
-	if (!model1) {
-		fprintf(stderr, "Could not create model\n");
-		return 1;
-	}
-
-	char fpath[1024];
-	size_t len;
-	unsigned char *ptr;
-
-	snprintf(fpath, 1024, "%s/saved_model.pb", argv[1]);
-	ptr = read_file(fpath, &len);
-	if (!ptr) {
-		fprintf(stderr, "Could not mmap saved_model.pb\n");
-		return 1;
-	}
-
-	ret = vaccel_tf_saved_model_set_model(model2, ptr, len);
-	if (ret) {
-		fprintf(stderr, "Could not set pb file for model\n");
-		return ret;
-	}
-
-	snprintf(fpath, 1024, "%s/variables/variables.data-00000-of-00001", argv[1]);
-	ptr = read_file(fpath, &len);
-	if (!ptr) {
-		fprintf(stderr, "Could not mmap checkpoint for model\n");
-		return 1;
-	}
-
-	ret = vaccel_tf_saved_model_set_checkpoint(model2, ptr, len);
-	if (ret) {
-		fprintf(stderr, "Could not set checkpoint file for model\n");
-		return ret;
-	}
-
-	snprintf(fpath, 1024, "%s/variables/variables.index", argv[1]);
-	ptr = read_file(fpath, &len);
-	if (!ptr) {
-		fprintf(stderr, "Could not mmap var index for model\n");
-		return 1;
-	}
-
-	ret = vaccel_tf_saved_model_set_var_index(model2, ptr, len);
-	if (ret) {
-		fprintf(stderr, "Could not set var index file for model\n");
-		return ret;
-	}
-
-	ret = vaccel_tf_saved_model_register(model2);
-	if (!model2) {
-		fprintf(stderr, "Could not create model\n");
-		return 1;
-	}
-
-	return 0;
+	vaccel_info("Testing SavedModel handling from in memory data");
+	return create_from_in_mem(argv[1]);
 }

--- a/src/include/resources/tf_saved_model.h
+++ b/src/include/resources/tf_saved_model.h
@@ -50,7 +50,7 @@ const char *vaccel_tf_saved_model_get_path(struct vaccel_tf_saved_model *model);
 
 int vaccel_tf_saved_model_set_model(
 	struct vaccel_tf_saved_model *model,
-	uint8_t *ptr, size_t len
+	const uint8_t *ptr, size_t len
 );
 
 const uint8_t *vaccel_tf_saved_model_get_model(
@@ -60,7 +60,7 @@ const uint8_t *vaccel_tf_saved_model_get_model(
 
 int vaccel_tf_saved_model_set_checkpoint(
 	struct vaccel_tf_saved_model *model,
-	uint8_t *ptr, size_t len
+	const uint8_t *ptr, size_t len
 );
 
 const uint8_t *vaccel_tf_saved_model_get_checkpoint(
@@ -70,7 +70,7 @@ const uint8_t *vaccel_tf_saved_model_get_checkpoint(
 
 int vaccel_tf_saved_model_set_var_index(
 	struct vaccel_tf_saved_model *model,
-	uint8_t *ptr, size_t len
+	const uint8_t *ptr, size_t len
 );
 
 const uint8_t *vaccel_tf_saved_model_get_var_index(

--- a/src/resources/file.c
+++ b/src/resources/file.c
@@ -110,9 +110,6 @@ int vaccel_file_persist(struct vaccel_file *file, const char *dir,
 		goto remove_file;
 	}
 
-	/* We do not need this any more */
-	free(old_ptr);
-
 	fclose(fp);
 	return VACCEL_OK;
 
@@ -131,8 +128,9 @@ free_path:
  * This will set the data of the file and it will persist
  * them in the filesystem if requested to do so.
  *
- * It takes ownership of the data, and it will deallocate
- * it when the file resource is destroyed.
+ * It does not take ownership of the data pointer, but the user is responsible
+ * of making sure that the memory it points to outlives the `vaccel_file`
+ * resource.
  */
 int vaccel_file_from_buffer(
 	struct vaccel_file *file,
@@ -165,14 +163,9 @@ int vaccel_file_destroy(struct vaccel_file *file)
 	if (!file)
 		return VACCEL_EINVAL;
 
-	/* Just a file with data we got from the user. Just free
-	 * the data */
-	if (!file->path) {
-		if (file->data)
-			free(file->data);
-
+	/* Just a file with data we got from the user. Nothing to do */
+	if (!file->path)
 		return VACCEL_OK;
-	}
 
 	/* There is a path in the disk representing the file,
 	 * which means that if we hold a pointer to the contents

--- a/src/resources/tf_saved_model.c
+++ b/src/resources/tf_saved_model.c
@@ -10,6 +10,7 @@
 #include <regex.h>
 #include <dirent.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #define MAX_PATH 1024
 
@@ -23,6 +24,19 @@ static int tf_model_destructor(void *data)
 	vaccel_file_destroy(&model->model);
 	vaccel_file_destroy(&model->checkpoint);
 	vaccel_file_destroy(&model->var_index);
+
+	struct vaccel_resource *res = model->resource;
+	if (!res || !res->rundir)
+		return VACCEL_OK;
+
+	char path[MAX_PATH];
+	if (snprintf(path, MAX_PATH, "%s/variables", res->rundir) >= MAX_PATH) {
+		vaccel_warn("Path too long");
+		return VACCEL_ENAMETOOLONG;
+	}
+
+	if (dir_exists(path))
+		rmdir(path);
 
 	return VACCEL_OK;
 }

--- a/src/resources/tf_saved_model.c
+++ b/src/resources/tf_saved_model.c
@@ -180,7 +180,7 @@ const char *vaccel_tf_saved_model_get_path(struct vaccel_tf_saved_model *model)
  */
 int vaccel_tf_saved_model_set_model(
 	struct vaccel_tf_saved_model *model,
-	uint8_t *ptr, size_t len
+	const uint8_t *ptr, size_t len
 ) {
 	vaccel_debug("Setting protobuf file for model");
 
@@ -224,7 +224,7 @@ const uint8_t *vaccel_tf_saved_model_get_model(
  */
 int vaccel_tf_saved_model_set_checkpoint(
 	struct vaccel_tf_saved_model *model,
-	uint8_t *ptr, size_t len
+	const uint8_t *ptr, size_t len
 ) {
 	vaccel_debug("Setting checkpoint file for model");
 
@@ -268,7 +268,7 @@ const uint8_t *vaccel_tf_saved_model_get_checkpoint(
  */
 int vaccel_tf_saved_model_set_var_index(
 	struct vaccel_tf_saved_model *model,
-	uint8_t *ptr, size_t len
+	const uint8_t *ptr, size_t len
 ) {
 	vaccel_debug("Setting variables index file for model");
 


### PR DESCRIPTION
When we persist a file in the file-system we mmap it to get a pointer to
its data. When destroying such a file we were using `free` to deallocate
the memory instead of `munmap` leading to crashes.

Moreover, when we had a vAccel file created from a buffer in memory,
e.g. that is the case when we receive a file over gRPC, and we persist
that file, we are writing the memory in the file and then mmaping it,
without though deallocating the initial memory pointer, leading to a
memory leak.

Finally, when cleaning up a TensorFlow SavedModel resource, we were not
removing the `variables` directory from the resource rundir, which was
obstructing cleaning up the rundir later on.

Signed-off-by: Babis Chalios <mail@bchalios.io>