### PR TITLE
tf: rename functions to reflect the actual calls

### DIFF
--- a/examples/tf_inference.c
+++ b/examples/tf_inference.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
 	}
 
 	struct vaccel_tf_status status;
-	ret = vaccel_tf_model_load_graph(&vsess, &model, &status);
+	ret = vaccel_tf_session_load(&vsess, &model, &status);
 	if (ret) {
 		fprintf(stderr, "Could not load graph from model\n");
 		goto unregister_resource;
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
 	struct vaccel_tf_node out_node = { "StatefulPartitionedCall", 0 };
 	struct vaccel_tf_tensor *out;
 
-	ret = vaccel_tf_model_run(&vsess, &model, &run_options,
+	ret = vaccel_tf_session_run(&vsess, &model, &run_options,
 			&in_node, &in, 1,
 			&out_node, &out, 1,
 			&status);

--- a/examples/tf_inference.c
+++ b/examples/tf_inference.c
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
 			&status);
 	if (ret) {
 		fprintf(stderr, "Could not run model: %d\n", ret);
-		goto unregister_resource;
+		goto unload_session;
 	}
 
 	printf("Success!\n");
@@ -108,6 +108,9 @@ int main(int argc, char *argv[])
 	float *offsets = (float *)out->data;
 	for (unsigned int i = 0; i < min(10, out->size / sizeof(float)) ; ++i)
 		printf("%f\n", offsets[i]);
+
+unload_session:
+	vaccel_tf_session_delete(&vsess, &model, &status);
 
 unregister_resource:
 	vaccel_sess_unregister(&vsess, model.resource);

--- a/plugins/noop/vaccel.c
+++ b/plugins/noop/vaccel.c
@@ -107,7 +107,7 @@ static int noop_exec(struct vaccel_session *sess, const char *library,
 	return VACCEL_OK;
 }
 
-static int noop_tf_model_load_graph(
+static int noop_tf_session_load(
 	struct vaccel_session *session,
 	struct vaccel_tf_saved_model *model,
 	struct vaccel_tf_status *status)
@@ -136,7 +136,7 @@ static int noop_tf_model_load_graph(
 	return VACCEL_OK;
 }
 
-static int noop_tf_model_run(
+static int noop_tf_session_run(
 	struct vaccel_session *session,
         const struct vaccel_tf_saved_model *model, const struct vaccel_tf_buffer *run_options,
         const struct vaccel_tf_node *in_nodes, struct vaccel_tf_tensor *const *in, int nr_inputs,
@@ -198,8 +198,8 @@ struct vaccel_op ops[] = {
 	VACCEL_OP_INIT(ops[3], VACCEL_IMG_DETEC, noop_img_detect),
 	VACCEL_OP_INIT(ops[4], VACCEL_IMG_SEGME, noop_img_segme),
 	VACCEL_OP_INIT(ops[5], VACCEL_EXEC, noop_exec),
-	VACCEL_OP_INIT(ops[6], VACCEL_TF_MODEL_LOAD_GRAPH, noop_tf_model_load_graph),
-	VACCEL_OP_INIT(ops[7], VACCEL_TF_MODEL_RUN_GRAPH, noop_tf_model_run),
+	VACCEL_OP_INIT(ops[6], VACCEL_TF_SESSION_LOAD, noop_tf_session_load),
+	VACCEL_OP_INIT(ops[7], VACCEL_TF_SESSION_RUN, noop_tf_session_run),
 };
 
 static int init(void)

--- a/plugins/noop/vaccel.c
+++ b/plugins/noop/vaccel.c
@@ -191,6 +191,30 @@ static int noop_tf_session_run(
 	return VACCEL_OK;
 }
 
+static int noop_tf_session_delete(
+	struct vaccel_session *session,
+        const struct vaccel_tf_saved_model *model,
+	struct vaccel_tf_status *status
+) {
+	if (!session) {
+		noop_error("Invalid session\n");
+		return VACCEL_EINVAL;
+	}
+
+	if (!model) {
+		noop_error("Invalid TensorFlow model\n");
+		return VACCEL_EINVAL;
+	}
+
+	if (status) {
+		status->message = strdup("Operation handled by noop plugin");
+		if (!status->message)
+			return VACCEL_ENOMEM;
+	}
+
+	return VACCEL_OK;
+}
+
 struct vaccel_op ops[] = {
 	VACCEL_OP_INIT(ops[0], VACCEL_NO_OP, noop_noop),
 	VACCEL_OP_INIT(ops[1], VACCEL_BLAS_SGEMM, noop_sgemm),
@@ -200,6 +224,7 @@ struct vaccel_op ops[] = {
 	VACCEL_OP_INIT(ops[5], VACCEL_EXEC, noop_exec),
 	VACCEL_OP_INIT(ops[6], VACCEL_TF_SESSION_LOAD, noop_tf_session_load),
 	VACCEL_OP_INIT(ops[7], VACCEL_TF_SESSION_RUN, noop_tf_session_run),
+	VACCEL_OP_INIT(ops[8], VACCEL_TF_SESSION_DELETE, noop_tf_session_delete),
 };
 
 static int init(void)

--- a/src/include/ops/tf.h
+++ b/src/include/ops/tf.h
@@ -144,3 +144,10 @@ int vaccel_tf_session_run(
         const struct vaccel_tf_node *out_nodes, struct vaccel_tf_tensor **out, int nr_outputs,
         struct vaccel_tf_status *status
 );
+
+
+int vaccel_tf_session_delete(
+	struct vaccel_session *session,
+	struct vaccel_tf_saved_model *model,
+	struct vaccel_tf_status *status
+);

--- a/src/include/ops/tf.h
+++ b/src/include/ops/tf.h
@@ -131,13 +131,13 @@ struct vaccel_tf_status {
         const char *message;
 };
 
-int vaccel_tf_model_load_graph(
+int vaccel_tf_session_load(
 	struct vaccel_session *session,
 	struct vaccel_tf_saved_model *model,
 	struct vaccel_tf_status *status
 );
 
-int vaccel_tf_model_run(
+int vaccel_tf_session_run(
 	struct vaccel_session *session,
         const struct vaccel_tf_saved_model *model, const struct vaccel_tf_buffer *run_options,
         const struct vaccel_tf_node *in_nodes, struct vaccel_tf_tensor *const *in, int nr_inputs,

--- a/src/include/ops/vaccel_ops.h
+++ b/src/include/ops/vaccel_ops.h
@@ -33,8 +33,8 @@ enum vaccel_op_type {
 	VACCEL_TF_MODEL_DESTROY,    /* 7 */
 	VACCEL_TF_MODEL_REGISTER,   /* 8 */
 	VACCEL_TF_MODEL_UNREGISTER, /* 9 */
-	VACCEL_TF_MODEL_LOAD_GRAPH, /* 10 */
-	VACCEL_TF_MODEL_RUN_GRAPH,  /* 11 */
+	VACCEL_TF_SESSION_LOAD,     /* 10 */
+	VACCEL_TF_SESSION_RUN,      /* 11 */
 	VACCEL_FUNCTIONS_NR
 };
 
@@ -49,8 +49,8 @@ static const char *vaccel_op_name[] = {
 	"TensorFlow model destroy",
 	"TensorFlow model register",
 	"TensorFlow model unregister",
-	"TensorFlow model load graph",
-	"TensorFlow model run graph",
+	"TensorFlow session load",
+	"TensorFlow session run",
 };
 
 static inline const char *vaccel_op_type_str(enum vaccel_op_type op_type)

--- a/src/include/ops/vaccel_ops.h
+++ b/src/include/ops/vaccel_ops.h
@@ -35,6 +35,7 @@ enum vaccel_op_type {
 	VACCEL_TF_MODEL_UNREGISTER, /* 9 */
 	VACCEL_TF_SESSION_LOAD,     /* 10 */
 	VACCEL_TF_SESSION_RUN,      /* 11 */
+	VACCEL_TF_SESSION_DELETE,   /* 12 */
 	VACCEL_FUNCTIONS_NR
 };
 
@@ -51,6 +52,7 @@ static const char *vaccel_op_name[] = {
 	"TensorFlow model unregister",
 	"TensorFlow session load",
 	"TensorFlow session run",
+	"TensorFlow session delete",
 };
 
 static inline const char *vaccel_op_type_str(enum vaccel_op_type op_type)

--- a/src/ops/tf.c
+++ b/src/ops/tf.c
@@ -228,7 +228,7 @@ void *vaccel_tf_tensor_get_data(struct vaccel_tf_tensor *tensor)
 	return tensor->data;
 }
 
-int vaccel_tf_model_load_graph(
+int vaccel_tf_session_load(
 	struct vaccel_session *session,
 	struct vaccel_tf_saved_model *model,
 	struct vaccel_tf_status *status)
@@ -245,14 +245,14 @@ int vaccel_tf_model_load_graph(
 		struct vaccel_session *,
 		struct vaccel_tf_saved_model *,
 		struct vaccel_tf_status *
-	) = get_plugin_op(VACCEL_TF_MODEL_LOAD_GRAPH);
+	) = get_plugin_op(VACCEL_TF_SESSION_LOAD);
 	if (!plugin_op)
 		return VACCEL_ENOTSUP;
 
 	return plugin_op(session, model, status);
 }
 
-int vaccel_tf_model_run(
+int vaccel_tf_session_run(
 	struct vaccel_session *session,
         const struct vaccel_tf_saved_model *model, const struct vaccel_tf_buffer *run_options,
         const struct vaccel_tf_node *in_nodes, struct vaccel_tf_tensor *const *in, int nr_inputs,
@@ -273,7 +273,7 @@ int vaccel_tf_model_run(
 		const struct vaccel_tf_node *, struct vaccel_tf_tensor *const *, int,
 		const struct vaccel_tf_node *, struct vaccel_tf_tensor **, int,
 		struct vaccel_tf_status *
-	) = get_plugin_op(VACCEL_TF_MODEL_RUN_GRAPH);
+	) = get_plugin_op(VACCEL_TF_SESSION_RUN);
 	if (!plugin_op)
 		return VACCEL_ENOTSUP;
 

--- a/src/ops/tf.c
+++ b/src/ops/tf.c
@@ -280,3 +280,25 @@ int vaccel_tf_session_run(
 	return plugin_op(session, model, run_options, in_nodes, in, nr_inputs,
 			out_nodes, out, nr_outputs, status);
 }
+
+int vaccel_tf_session_delete(
+	struct vaccel_session *session,
+	struct vaccel_tf_saved_model *model,
+	struct vaccel_tf_status *status
+) {
+	vaccel_debug("TensorFlow: delete session");
+
+	if (!session) {
+		vaccel_debug("Invalid vAccel session");
+		return VACCEL_EINVAL;
+	}
+
+	int (*plugin_op)(
+		struct vaccel_session *, struct vaccel_tf_saved_model *,
+		struct vaccel_tf_status *
+	) = get_plugin_op(VACCEL_TF_SESSION_DELETE);
+	if (!plugin_op)
+		return VACCEL_ENOTSUP;
+
+	return plugin_op(session, model, status);
+}


### PR DESCRIPTION
Names of the functions for loading a session from a SavedModel and
running a session were confusing and did not reflect the usage of
the 2.0 API and saved models.

Signed-off-by: Babis Chalios <mail@bchalios.io>