### PR TITLE
Add initial profiling support

### DIFF
--- a/CMakeLists.txt.in
+++ b/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           release-1.8.1
+  GIT_TAG           release-1.11.0
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/src/include/vaccel_prof.h
+++ b/src/include/vaccel_prof.h
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "error.h"
+
+struct prof_sample;
+
+struct vaccel_prof_region {
+	/* Name of the region */
+	const char *name;
+
+	/* 'true' if we own the memory of 'name' */
+	bool name_owned;
+
+	/* Number of collected samples */
+	size_t nr_entries;
+
+	/* Array of collected samples */
+	struct prof_sample *samples;
+
+	/* Allocated size for the array */
+	size_t size;
+};
+
+#define VACCEL_PROF_REGION_INIT(name) { (name), false, 0, NULL, 0 }
+
+/* Start profiling a region */
+int vaccel_prof_region_start(struct vaccel_prof_region *region);
+
+/* Stop profiling a region */
+int vaccel_prof_region_stop(const struct vaccel_prof_region *region);
+
+/* Dump profiling results of a region */
+int vaccel_prof_region_print(const struct vaccel_prof_region *region);
+
+/* Initialize a profiling region */
+int vaccel_prof_region_init(
+	struct vaccel_prof_region *region,
+	const char *name
+);
+
+/* Destroy a profiling region */
+int vaccel_prof_region_destroy(struct vaccel_prof_region *region);

--- a/src/log.c
+++ b/src/log.c
@@ -66,8 +66,8 @@ static void set_log_file(void)
 	slog_config_get(&cfg);
 	strncpy(cfg.sFileName, env, SLOG_NAME_MAX-1);
 
-	if (strncpy(cfg.sFileName, "/dev/stdout", SLOG_NAME_MAX-1)
-			&& strncpy(cfg.sFileName, "/dev/stderr", SLOG_NAME_MAX-1)) {
+	if (strncmp(cfg.sFileName, "/dev/stdout", SLOG_NAME_MAX-1)
+			&& strncmp(cfg.sFileName, "/dev/stderr", SLOG_NAME_MAX-1)) {
 		cfg.nToFile = 1;
 		cfg.nToScreen = 0;
 	}

--- a/src/profiling/vaccel_prof.c
+++ b/src/profiling/vaccel_prof.c
@@ -19,6 +19,7 @@
 
 #include <malloc.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <stddef.h>
 #include <string.h>
 #include <time.h>
@@ -32,6 +33,13 @@ uint64_t get_tstamp_nsec(void)
 	clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
 
 	return tp.tv_sec * 1e9 + tp.tv_nsec;
+}
+
+static bool prof_enabled(void)
+{
+	char *env = getenv("VACCEL_PROF_ENABLED");
+
+	return env && !strncmp(env, "enabled", 7);
 }
 
 struct prof_sample {
@@ -104,6 +112,9 @@ static struct prof_sample *get_next_sample(struct vaccel_prof_region *region)
 
 int vaccel_prof_region_start(struct vaccel_prof_region *region)
 {
+	if (!prof_enabled())
+		return VACCEL_OK;
+
 	if (!region) {
 		vaccel_error("[prof] start region: Invalid profiling region");
 		return VACCEL_EINVAL;
@@ -122,6 +133,9 @@ int vaccel_prof_region_start(struct vaccel_prof_region *region)
 
 int vaccel_prof_region_stop(const struct vaccel_prof_region *region)
 {
+	if (!prof_enabled())
+		return VACCEL_OK;
+
 	if (!region) {
 		vaccel_error("[prof] stop region: Invalid profiling region");
 		return VACCEL_EINVAL;
@@ -142,6 +156,9 @@ int vaccel_prof_region_init(
 	struct vaccel_prof_region *region,
 	const char *name
 ) {
+	if (!prof_enabled())
+		return VACCEL_OK;
+
 	if (!region) {
 		vaccel_error("[prof] init region: Invalid profiling region");
 		return VACCEL_EINVAL;
@@ -171,6 +188,9 @@ free_name:
 
 int vaccel_prof_region_destroy(struct vaccel_prof_region *region)
 {
+	if (!prof_enabled())
+		return VACCEL_OK;
+
 	if (!region) {
 		vaccel_error("[prof] destroy region: Invalid profiling region");
 		return VACCEL_EINVAL;
@@ -193,6 +213,9 @@ int vaccel_prof_region_destroy(struct vaccel_prof_region *region)
 
 int vaccel_prof_region_print(const struct vaccel_prof_region *region)
 {
+	if (!prof_enabled())
+		return VACCEL_OK;
+
 	if (!region) {
 		vaccel_error("[prof] print region: Invalid profiling region");
 		return VACCEL_EINVAL;

--- a/src/profiling/vaccel_prof.c
+++ b/src/profiling/vaccel_prof.c
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vaccel_prof.h"
+
+#include "log.h"
+#include "error.h"
+
+#include <malloc.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <time.h>
+
+#define MIN_SAMPLES 1024
+
+uint64_t get_tstamp_nsec(void)
+{
+	struct timespec tp;
+
+	clock_gettime(CLOCK_MONOTONIC_RAW, &tp);
+
+	return tp.tv_sec * 1e9 + tp.tv_nsec;
+}
+
+struct prof_sample {
+	/* Timestamp (nsec) of entering the region */
+	uint64_t tstamp_start;
+
+	/* Timestamp (nsec) of exiting the region */
+	uint64_t tstamp_end;
+};
+
+void prof_sample_start(struct prof_sample *sample)
+{
+	sample->tstamp_start = get_tstamp_nsec();
+}
+
+void prof_sample_stop(struct prof_sample *sample)
+{
+	sample->tstamp_end = get_tstamp_nsec();
+}
+
+uint64_t prof_sample_duration(struct prof_sample *sample)
+{
+	return sample->tstamp_end - sample->tstamp_start;
+}
+
+static int grow_samples_array(struct vaccel_prof_region *region)
+{
+	size_t alloc_size = (region->size) ? region->size * 2 : MIN_SAMPLES;
+
+	struct prof_sample *new_ptr =
+		realloc(region->samples, alloc_size * sizeof(*new_ptr));
+	if (!new_ptr)
+		return VACCEL_ENOMEM;
+
+	region->samples = new_ptr;
+	region->size = alloc_size;
+
+	return VACCEL_OK;
+}
+
+/* This will return that last used sample entry or NULL if no entries
+ * have been used */
+static struct prof_sample *get_last_sample(
+	const struct vaccel_prof_region *region
+) {
+	size_t size = region->nr_entries;
+
+	if (!size)
+		return NULL;
+
+	return &region->samples[size - 1];
+}
+
+/* Get next available profiling sample entry
+ *
+ * This will return the first unused sample entry. If needed it will
+ * grow the capacity of the array */
+static struct prof_sample *get_next_sample(struct vaccel_prof_region *region)
+{
+	size_t pos = region->nr_entries;
+
+	/* The array is full. Try to grow it */
+	if (pos >= region->size)
+		if (grow_samples_array(region) != VACCEL_OK)
+			return NULL;
+
+	region->nr_entries++;
+	return &region->samples[pos];
+}
+
+int vaccel_prof_region_start(struct vaccel_prof_region *region)
+{
+	if (!region) {
+		vaccel_error("[prof] start region: Invalid profiling region");
+		return VACCEL_EINVAL;
+	}
+
+	vaccel_debug("Start profiling region %s", region->name);
+
+	struct prof_sample *sample = get_next_sample(region);
+	if (!sample)
+		return VACCEL_ENOMEM;
+
+	prof_sample_start(sample);
+
+	return VACCEL_OK;
+}
+
+int vaccel_prof_region_stop(const struct vaccel_prof_region *region)
+{
+	if (!region) {
+		vaccel_error("[prof] stop region: Invalid profiling region");
+		return VACCEL_EINVAL;
+	}
+
+	vaccel_debug("Stop profiling region %s", region->name);
+
+	struct prof_sample *sample = get_last_sample(region);
+	if (!sample)
+		return VACCEL_ENOENT;
+
+	prof_sample_stop(sample);
+
+	return VACCEL_OK;
+}
+
+int vaccel_prof_region_init(
+	struct vaccel_prof_region *region,
+	const char *name
+) {
+	if (!region) {
+		vaccel_error("[prof] init region: Invalid profiling region");
+		return VACCEL_EINVAL;
+	}
+
+	if (!name) {
+		vaccel_error("[prof] init region: Invalid region name");
+		return VACCEL_EINVAL;
+	}
+
+	region->name = strdup(name);
+	if (!region->name)
+		return VACCEL_ENOMEM;
+
+	region->name_owned = true;
+
+	region->nr_entries = 0;
+	if (grow_samples_array(region) != VACCEL_OK)
+		goto free_name;
+
+	return VACCEL_OK;
+	
+free_name:
+	free((void *)region->name);
+	return VACCEL_ENOMEM;
+}
+
+int vaccel_prof_region_destroy(struct vaccel_prof_region *region)
+{
+	if (!region) {
+		vaccel_error("[prof] destroy region: Invalid profiling region");
+		return VACCEL_EINVAL;
+	}
+
+	if (region->samples)
+		free(region->samples);
+
+	if (region->name && region->name_owned)
+		free((void *)region->name);
+
+	region->name = NULL;
+	region->name_owned = false;
+	region->nr_entries = 0;
+	region->samples = NULL;
+	region->size = 0;
+
+	return VACCEL_OK;
+}
+
+int vaccel_prof_region_print(const struct vaccel_prof_region *region)
+{
+	if (!region) {
+		vaccel_error("[prof] print region: Invalid profiling region");
+		return VACCEL_EINVAL;
+	}
+
+	if (!region->nr_entries)
+		return VACCEL_OK;
+
+	uint64_t total_time = 0;
+	for (size_t i = 0; i < region->nr_entries; ++i)
+		total_time += prof_sample_duration(&region->samples[i]);
+
+	vaccel_info("[prof] %s: total_time: %lu nsec nr_entries: %lu",
+			region->name, total_time, region->nr_entries);
+
+	return VACCEL_OK;
+}

--- a/src/profiling/vaccel_prof.h
+++ b/src/profiling/vaccel_prof.h
@@ -12,23 +12,6 @@
  * limitations under the License.
  */
 
-#ifndef __VACCEL_H__
-#define __VACCEL_H__
+#pragma once
 
-#include "error.h"
-#include "log.h"
-#include "plugin.h"
-#include "session.h"
-#include "tf_model.h"
-#include "vaccel_id.h"
-#include "ops/vaccel_ops.h"
-#include "ops/blas.h"
-#include "ops/exec.h"
-#include "ops/genop.h"
-#include "ops/image.h"
-#include "ops/noop.h"
-#include "ops/tf.h"
-#include "resources/tf_saved_model.h"
-#include "vaccel_prof.h"
-
-#endif /* __VACCEL_H__ */
+#include "include/vaccel_prof.h"


### PR DESCRIPTION
Add an (externally visible) vAccel API that allows defining profiling
regions for which we can gather statistics.

At the moment, the only statistics we gather is execution time of each
invocation of such a profiling region and the number of times we entered
this region.

Signed-off-by: Babis Chalios <mail@bchalios.io>