### PR TITLE
Initialize logger at lib load

### DIFF
--- a/src/vaccel.c
+++ b/src/vaccel.c
@@ -159,7 +159,14 @@ const char *vaccel_rundir(void)
 __attribute__((constructor))
 static void vaccel_init(void)
 {
-	int ret = create_vaccel_rundir();
+	int ret = VACCEL_EINVAL;
+
+	/* Initialize logger */
+	vaccel_log_init();
+
+	vaccel_debug("Initializing vAccel");
+
+	ret = create_vaccel_rundir();
 	if (ret) {
 		vaccel_error("Could not create rundir for vAccel");
 		exit(ret);
@@ -176,11 +183,6 @@ static void vaccel_init(void)
 		vaccel_error("Could not bootstrap resources system");
 		exit(ret);
 	}
-
-	/* Initialize logger */
-	vaccel_log_init();
-
-	vaccel_debug("Initializing vAccel");
 
 	/* initialize the backends system */
 	plugins_bootstrap();


### PR DESCRIPTION
When loading `libvaccel.so`, logging is not enabled before rundir creation. If this fails, we do not get informed aproprietly. This patch initializes logging at library load.

Signed-off-by: Maria Goutha <mgouth@nubificus.co.uk>
Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>