### PR TITLE
Add minmax over genop

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,6 +15,7 @@ set(BIN_EXAMPLES
 	noop
 	sgemm
 	minmax
+	minmax_generic
 	tf_model
 	tf_inference
 	tf_saved_model)

--- a/examples/minmax_generic.c
+++ b/examples/minmax_generic.c
@@ -64,9 +64,24 @@ int main(int argc, char *argv[])
 
 	struct timespec t0, t1;
 
+	enum vaccel_op_type op_type = VACCEL_MINMAX;
+	struct vaccel_arg read[5] = {
+		{ .size = sizeof(enum vaccel_op_type), .buf = &op_type},
+		{ .size = ndata * sizeof(double), .buf = indata},
+		{ .size = sizeof(int), .buf = &ndata},
+		{ .size = sizeof(int), .buf = &low_threshold},
+		{ .size = sizeof(int), .buf = &high_threshold},
+	};
+	struct vaccel_arg write[3] = {
+		{ .size = sizeof(double), .buf = outdata},
+		{ .size = sizeof(double), .buf = &min},
+		{ .size = sizeof(double), .buf = &max},
+	};
+
 	clock_gettime(CLOCK_MONOTONIC_RAW, &t0);
-	ret = vaccel_minmax(&session, indata, ndata, low_threshold,
-			high_threshold, outdata, &min, &max);
+	ret = vaccel_genop(&session, &read[0], 5, &write[0], 3);
+	//ret = vaccel_minmax(&session, indata, ndata, low_threshold,
+			//high_threshold, outdata, &min, &max);
 	clock_gettime(CLOCK_MONOTONIC_RAW, &t1);
 	if (ret) {
 		fprintf(stderr, "Could not run kernel: %d\n", ret);

--- a/plugins/noop/vaccel.c
+++ b/plugins/noop/vaccel.c
@@ -71,12 +71,13 @@ int noop_minmax(
 	fprintf(stdout, "[noop] Calling minmax for session %u\n",
 		sess->session_id);
 
-	fprintf(stdout, "[noop] Dumping arguments for minmax :\n");
+	fprintf(stdout, "[noop] Dumping arguments for minmax: ndata:%d\n", ndata);
 	fprintf(stdout, "[noop] low: %d high: %d \n", low_threshold, high_threshold);
 
 
-        *min = tmp_min;
+        *outdata = tmp_min;
         *max = tmp_max;
+        *min = tmp_min;
 
         return VACCEL_OK;
 }

--- a/src/ops/genop.c
+++ b/src/ops/genop.c
@@ -16,6 +16,7 @@
 #include "vaccel_ops.h"
 
 #include "blas.h"
+#include "minmax.h"
 #include "exec.h"
 #include "image.h"
 #include "noop.h"
@@ -41,6 +42,14 @@ unpack_func_t callbacks[VACCEL_FUNCTIONS_NR] = {
 	vaccel_image_pose_unpack,
 	vaccel_image_depth_unpack,
 	vaccel_exec_unpack,
+	vaccel_noop_unpack,
+	vaccel_noop_unpack,
+	vaccel_noop_unpack,
+	vaccel_noop_unpack,
+	vaccel_noop_unpack,
+	vaccel_noop_unpack,
+	vaccel_noop_unpack,
+	vaccel_minmax_unpack,
 };
 
 int vaccel_genop(struct vaccel_session *sess, struct vaccel_arg  *read,

--- a/src/ops/minmax.c
+++ b/src/ops/minmax.c
@@ -34,3 +34,34 @@ int vaccel_minmax(
 	return plugin_op(sess, indata, ndata, low_threshold, high_threshold,
 			outdata, min, max);
 }
+
+int vaccel_minmax_unpack(
+	struct vaccel_session *sess,
+	struct vaccel_arg *read, int nr_read,
+	struct vaccel_arg *write, int nr_write
+) {
+	if (nr_read != 4) {
+		vaccel_error("Wrong number of read arguments in MinMax: %d",
+				nr_read);
+		return VACCEL_EINVAL;
+	}
+
+	if (nr_write != 3) {
+		vaccel_error("Wrong number of write arguments in SGEMM: %d",
+				nr_write);
+		return VACCEL_EINVAL;
+	}
+
+	double *indata = (double *)read[0].buf;
+	int ndata = *(int*)read[1].buf;
+	int low_threshold = *(int*)read[2].buf;
+	int high_threshold = *(int*)read[3].buf;
+
+	vaccel_info("number of data: %d\n", *(int*)read[1].buf);
+	vaccel_info("number of data: %d\n", ndata);
+	double *outdata = (double *)write[0].buf;
+	double *min = (double *)write[1].buf;
+	double *max = (double *)write[2].buf;
+
+	return vaccel_minmax(sess, indata, ndata, low_threshold, high_threshold, outdata, min, max);
+}

--- a/src/ops/minmax.h
+++ b/src/ops/minmax.h
@@ -1,3 +1,7 @@
 #pragma once
 
+
 #include "include/ops/minmax.h"
+
+int vaccel_minmax_unpack(struct vaccel_session *sess, struct vaccel_arg *read,
+		int nr_read, struct vaccel_arg *write, int nr_write);


### PR DESCRIPTION
Port the minmax operation over genop.

TODO: fix genop's handlers to account for the exact vAccel API IDs. For now, we use noop_unpack to replace the TF operations

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>