### PR TITLE
Add the libvaccel-python.so helper lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 project(vaccelrt
-	VERSION 0.1
+	VERSION 0.5.0
 	DESCRIPTION "VaccelRT library"
 	LANGUAGES C CXX)
 
@@ -62,3 +62,10 @@ if (ENABLE_TESTS)
 	enable_testing()
 	add_subdirectory(test)
 endif (ENABLE_TESTS)
+
+set(CPACK_PACKAGE_NAME vaccel)
+set(CPACK_PACKAGE_CONTACT "Anastassios Nanos <ananos@nubificus.co.uk>")
+set(CPACK_GENERATOR DEB)
+set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ include_directories(
 
 add_subdirectory(src)
 add_subdirectory(plugins)
+add_subdirectory(python)
 
 if (BUILD_EXAMPLES)
 	add_subdirectory(examples)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,23 @@
+file(GLOB_RECURSE sources *.c)
+
+# core runtime headers
+file(GLOB_RECURSE headers *.h)
+
+add_library(vaccel-python SHARED ${headers} ${sources})
+target_compile_options(vaccel-python PUBLIC -Wall -Wextra -Werror -pthread)
+target_include_directories(vaccel-python PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(vaccel-python PRIVATE ${CMAKE_SOURCE_DIR}/src/include)
+set_property(TARGET vaccel-python PROPERTY LINK_FLAGS "-pthread")
+set_property(TARGET vaccel-python PROPERTY C_STANDARD 11)
+target_link_libraries(vaccel-python)
+
+# Setup make install
+install(TARGETS vaccel-python DESTINATION ${CMAKE_INSTALL_LIBDIR})
+#install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# Create the pkg-config file
+set(DEST_DIR "${CMAKE_INSTALL_PREFIX}")
+CONFIGURE_FILE("vaccel-python.pc.in" "vaccel-python.pc" @ONLY)
+
+# Install the vaccel.pc file
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/vaccel-python.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR})

--- a/python/helper.c
+++ b/python/helper.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <vaccel.h>
+#include <plugin.h>
+#include <assert.h>
+
+__attribute__((constructor))
+void load_vaccel(void)
+{
+	printf("Loading libvaccel\n");
+	void *dl = dlopen("libvaccel.so", RTLD_LAZY | RTLD_GLOBAL);
+	if (!dl) {
+		fprintf(stderr, "Could not open libvaccel\n");
+		exit(1);
+	}
+
+	char *pname = getenv("PYTHON_VACCEL_PLUGIN");
+	printf("Loading plugin %s\n", pname);
+	void *plugin = dlopen(pname, RTLD_NOW);
+	if (!plugin) {
+		fprintf(stderr, "Failed to load plugin: %s\n", dlerror());
+		exit(1);
+	}
+
+	struct vaccel_plugin **p;
+
+	int (*register_plugin)(struct vaccel_plugin *) =
+		dlsym(dl, "register_plugin");
+	assert(register_plugin);
+
+	p = dlsym(plugin, "vaccel_plugin");
+	if (p == NULL) {
+		fprintf(stderr, "Cannot find vaccel_plugin symbol\n");
+		return;
+	}
+	assert(p);
+
+	int ret = register_plugin(*p);
+	assert(!ret);
+	if (ret) {
+		fprintf(stderr, "Failed to register plugin\n");
+		return;
+	}
+		
+	ret = (*p)->info->init();
+	assert(!ret);
+	if (ret) {
+		fprintf(stderr, "Failed to initialize plugin\n");
+		return;
+	}
+}

--- a/python/vaccel-python.pc.in
+++ b/python/vaccel-python.pc.in
@@ -1,0 +1,11 @@
+prefix=@DEST_DIR@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libvaccel-python
+Description: Transparent acceleration for edge and cloud computing hack
+Version: 0.4.0
+
+Libs: -L${libdir} -lvaccel-python
+Cflags: -I${includedir}


### PR DESCRIPTION
libpython.so loads all dependent libraries lazily. This does not work for us, so by using this dummy wrapper, we force the loader to resolve all lib dependencies at load time.

eg, see: https://github.com/python/cpython/issues/65735#issuecomment-1235768965

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>