### PR TITLE
Allow python helper to load more than one plugin

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,7 +5,7 @@ file(GLOB_RECURSE headers *.h)
 
 add_library(vaccel-python SHARED ${headers} ${sources})
 target_compile_options(vaccel-python PUBLIC -Wall -Wextra -Werror -pthread)
-target_include_directories(vaccel-python PRIVATE ${CMAKE_SOURCE_DIR}/src)
+#target_include_directories(vaccel-python PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(vaccel-python PRIVATE ${CMAKE_SOURCE_DIR}/src/include)
 set_property(TARGET vaccel-python PROPERTY LINK_FLAGS "-pthread")
 set_property(TARGET vaccel-python PROPERTY C_STANDARD 11)

--- a/python/helper.c
+++ b/python/helper.c
@@ -1,52 +1,113 @@
 #include <stdio.h>
 #include <dlfcn.h>
 #include <stdlib.h>
-#include <vaccel.h>
 #include <plugin.h>
+#include <vaccel.h>
+#include <string.h>
 #include <assert.h>
+
+void *vacceldl = NULL;
+char *pname = NULL;
+
+/* Copied from vaccelrt/src/vaccel.c */
+static int load_backend_plugin(const char *path)
+{
+	int ret;
+	struct vaccel_plugin *plugin, **plugin_p;
+
+	void *dl = dlopen(path, RTLD_LAZY);
+	if (!dl) {
+		printf("Could not dlopen plugin %s: %s", path, dlerror());
+		return VACCEL_ENOENT;
+	}
+
+	plugin_p = dlsym(dl, "vaccel_plugin");
+	if (!plugin_p) {
+		printf("Not a vaccel plugin: %s", path);
+		ret = VACCEL_ELIBBAD;
+		goto close_dl;
+	}
+
+	plugin = *plugin_p;
+	int (*register_plugin)(struct vaccel_plugin *) =
+		dlsym(vacceldl, "register_plugin");
+	assert(register_plugin);
+
+	ret = register_plugin(plugin);
+	if (ret != VACCEL_OK)
+		goto close_dl;
+
+	/* Initialize the plugin */
+	ret = plugin->info->init();
+	if (ret != VACCEL_OK)
+		goto close_dl;
+
+	/* Keep dl handle so we can later close the library */
+	plugin->dl_handle = dl;
+
+	printf("Loaded plugin %s from %s\n", plugin->info->name, path);
+
+	return VACCEL_OK;
+
+close_dl:
+	dlclose(dl);
+	return ret;
+}
+
+/* Copied from vaccelrt/src/vaccel.c */
+int load_backend_plugins(char *plugins)
+{
+	char *plugin;
+
+	char *plugins_tmp = strdup(plugins);
+	if (!plugins_tmp)
+		return VACCEL_ENOMEM;
+
+	char *p = plugins_tmp;
+	plugin = strtok(p, ":");
+	while (plugin) {
+		printf("Loading plugin: %s\n", plugin);
+		int ret = load_backend_plugin(plugin);
+		if (ret != VACCEL_OK)
+			return ret;
+
+		plugin = strtok(NULL, ":");
+	}
+	
+	free(plugins_tmp);
+	return VACCEL_OK;
+}
 
 __attribute__((constructor))
 void load_vaccel(void)
 {
+	/* Get a copy of the plugin env variable */
+	pname = strdup(getenv("VACCEL_BACKENDS"));
+
+	/* Do not allow libvaccel.so to load the plugins
+	   as we get unresolved symbols. See:
+	   https://mail.python.org/pipermail/python-dev/2002-May/023923.html */
+	unsetenv("VACCEL_BACKENDS");
+
 	printf("Loading libvaccel\n");
-	void *dl = dlopen("libvaccel.so", RTLD_LAZY | RTLD_GLOBAL);
-	if (!dl) {
+	vacceldl = dlopen("libvaccel.so", RTLD_LAZY | RTLD_GLOBAL);
+	if (!vacceldl) {
 		fprintf(stderr, "Could not open libvaccel\n");
 		exit(1);
 	}
 
-	char *pname = getenv("PYTHON_VACCEL_PLUGIN");
-	printf("Loading plugin %s\n", pname);
-	void *plugin = dlopen(pname, RTLD_NOW);
-	if (!plugin) {
-		fprintf(stderr, "Failed to load plugin: %s\n", dlerror());
-		exit(1);
-	}
+	/* Instead, load the plugins now */
+	printf("Loading plugins\n");
+	load_backend_plugins(pname);
 
-	struct vaccel_plugin **p;
+}
 
-	int (*register_plugin)(struct vaccel_plugin *) =
-		dlsym(dl, "register_plugin");
-	assert(register_plugin);
-
-	p = dlsym(plugin, "vaccel_plugin");
-	if (p == NULL) {
-		fprintf(stderr, "Cannot find vaccel_plugin symbol\n");
-		return;
-	}
-	assert(p);
-
-	int ret = register_plugin(*p);
-	assert(!ret);
-	if (ret) {
-		fprintf(stderr, "Failed to register plugin\n");
-		return;
-	}
-		
-	ret = (*p)->info->init();
-	assert(!ret);
-	if (ret) {
-		fprintf(stderr, "Failed to initialize plugin\n");
-		return;
-	}
+__attribute__((destructor))
+static void unload_vaccel(void)
+{
+        printf("Shutting down vAccel\n");
+	/* This will unregister and free resources of the plugins */
+	dlclose(vacceldl);
+	if (pname)
+		free(pname);
 }


### PR DESCRIPTION
Duplicate some of the plugin code to allow loading more than one plugin when calling vAccel functions from Python.

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>