### PR TITLE
resources: randomize object filename

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ self-hosted, "${{ matrix.archconfig }}", gcc, lite ]
     strategy:
       matrix:
-        archconfig: [ x86_64, aarch64, aarch32 ]
+        archconfig: [ x86_64, aarch64, armv7l ]
         build_type: [ Debug, Release ]
       fail-fast: false
     steps:
@@ -66,7 +66,7 @@ jobs:
         echo ::set-output name=NAME::$(basename build_${{ matrix.build_type }}/vaccel-*.tar.gz)
 
     - name: Upload artifact to s3
-      uses: cloudkernels/minio-upload@v3
+      uses: cloudkernels/minio-upload@v4
       with:
         url: https://s3.nubificus.co.uk
         access-key: ${{ secrets.AWS_ACCESS_KEY }}
@@ -76,7 +76,7 @@ jobs:
         policy: 1
 
     - name: Upload artifact to s3
-      uses: cloudkernels/minio-upload@v3
+      uses: cloudkernels/minio-upload@v4
       with:
         url: https://s3.nubificus.co.uk
         access-key: ${{ secrets.AWS_ACCESS_KEY }}

--- a/.github/workflows/test_vaccelrt.yml
+++ b/.github/workflows/test_vaccelrt.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        archconfig: [ x86_64, aarch64, aarch32 ]
+        archconfig: [ x86_64, aarch64, armv7l ]
         build_type: [Debug, Release]
       fail-fast: false
 
@@ -95,7 +95,7 @@ jobs:
         ./bin/pynq_parallel
 
     - name: Upload artifact to s3
-      uses: cloudkernels/minio-upload@v3
+      uses: cloudkernels/minio-upload@v4
       with:
         url: https://s3.nubificus.co.uk
         access-key: ${{ secrets.AWS_ACCESS_KEY }}


### PR DESCRIPTION
We hit a really weird issue when running exec with resource over vsock. Essentially, any consecutive calls to the same resource file (even if the session is closed and the resource is freed) keep using the data of the first resource passed.

For now, we can just randomize the name of the file, but this is not a permanent solution.

Wild guess: this points to some weird cache issue either with mmap() of with the rust<->C mmap() call. Major FIXME!!