### PR TITLE
add argument to control the randomizing of the filename

### DIFF
--- a/examples/tf_inference.c
+++ b/examples/tf_inference.c
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
 	/* Input tensors & nodes */
 	struct vaccel_tf_node in_node = { "serving_default_input_1", 0 };
 	
-	long long int dims[] = {1, 30};
+	uint32_t dims[] = {1, 30};
 	float data[30];
 	for (int i = 0; i < 30; ++i)
 		data[i] = 1.00;
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 	printf("Success!\n");
 	printf("Output tensor => type:%u nr_dims:%u\n", out->data_type, out->nr_dims);
 	for (int i = 0; i < out->nr_dims; ++i)
-		printf("dim[%d]: %lld\n", i, out->dims[i]);
+		printf("dim[%d]: %d\n", i, out->dims[i]);
 		
 	printf("Result Tensor :\n");
 	float *offsets = (float *)out->data;

--- a/plugins/noop/vaccel.c
+++ b/plugins/noop/vaccel.c
@@ -257,7 +257,7 @@ static int noop_tf_session_run(
 				in_nodes[i].id);
 		noop_info("\t#dims: %d -> {", in[i]->nr_dims);
 		for (int j = 0; j < in[i]->nr_dims; ++j)
-			printf("%lld%s", in[i]->dims[j],
+			printf("%d%s", in[i]->dims[j],
 				(j == in[i]->nr_dims - 1) ? "}\n" : " ");
 
 		noop_info("\tData type: %d\n", in[i]->data_type);

--- a/src/include/ops/tf.h
+++ b/src/include/ops/tf.h
@@ -93,7 +93,7 @@ struct vaccel_tf_tensor {
 
         /* dimensions of the data */
         int nr_dims;
-        long long int *dims;
+        uint32_t *dims;
 
         /* Data type */
         enum vaccel_tf_data_type data_type;
@@ -102,13 +102,13 @@ struct vaccel_tf_tensor {
 struct vaccel_tf_tensor *
 vaccel_tf_tensor_new(
 	int nr_dims,
-	long long int *dims,
+	uint32_t  *dims,
 	enum vaccel_tf_data_type type
 );
 
 struct vaccel_tf_tensor *
 vaccel_tf_tensor_allocate(
-	int nr_dims, long long int *dims,
+	int nr_dims, uint32_t *dims,
 	enum vaccel_tf_data_type type,
 	size_t total_size
 );

--- a/src/include/vaccel_file.h
+++ b/src/include/vaccel_file.h
@@ -45,12 +45,14 @@ int vaccel_file_from_buffer(
 	size_t size,
 	const char *filename,
 	bool persist,
-	const char *dir
+	const char *dir,
+	bool randomize
 );
 int vaccel_file_persist(
 	struct vaccel_file *file,
 	const char *dir,
-	const char *filename
+	const char *filename,
+	bool randomize
 );
 int vaccel_file_destroy(struct vaccel_file *file);
 bool vaccel_file_initialized(struct vaccel_file *file);

--- a/src/ops/tf.c
+++ b/src/ops/tf.c
@@ -140,7 +140,7 @@ long long int vaccel_tf_node_get_id(struct vaccel_tf_node *node)
 }
 
 struct vaccel_tf_tensor *
-vaccel_tf_tensor_new(int nr_dims, long long int *dims, enum vaccel_tf_data_type type)
+vaccel_tf_tensor_new(int nr_dims, uint32_t *dims, enum vaccel_tf_data_type type)
 {
 	struct vaccel_tf_tensor *ret;
 
@@ -164,7 +164,7 @@ vaccel_tf_tensor_new(int nr_dims, long long int *dims, enum vaccel_tf_data_type 
 
 struct vaccel_tf_tensor *
 vaccel_tf_tensor_allocate(
-	int nr_dims, long long int *dims,
+	int nr_dims, uint32_t *dims,
 	enum vaccel_tf_data_type type,
 	size_t total_size
 ) {

--- a/src/resources/shared_object.c
+++ b/src/resources/shared_object.c
@@ -73,7 +73,7 @@ int vaccel_shared_object_new_from_buffer(struct vaccel_shared_object *object,
 		return VACCEL_ENOMEM;
 
 	int ret = vaccel_file_from_buffer(&object->file, buff, size, NULL,
-			NULL, false);
+			NULL, false, false);
 	if (ret)
 		goto free_resource;
 
@@ -88,7 +88,7 @@ int vaccel_shared_object_new_from_buffer(struct vaccel_shared_object *object,
 
 	vaccel_debug("New rundir for resource %s", res->rundir);
 
-	ret = vaccel_file_persist(&object->file, res->rundir, "lib.so");
+	ret = vaccel_file_persist(&object->file, res->rundir, "lib.so", true);
 	if (ret)
 		goto destroy_resource;
 

--- a/src/resources/tf_model.c
+++ b/src/resources/tf_model.c
@@ -73,7 +73,7 @@ int vaccel_tf_model_new_from_buffer(struct vaccel_tf_model *model,
 		return VACCEL_ENOMEM;
 
 	int ret = vaccel_file_from_buffer(&model->file, buff, size, NULL,
-			NULL, false);
+			NULL, false, false);
 	if (ret)
 		goto free_resource;
 
@@ -88,7 +88,7 @@ int vaccel_tf_model_new_from_buffer(struct vaccel_tf_model *model,
 
 	vaccel_debug("New rundir for resource %s", res->rundir);
 
-	ret = vaccel_file_persist(&model->file, res->rundir, "model.pb");
+	ret = vaccel_file_persist(&model->file, res->rundir, "model.pb", false);
 	if (ret)
 		goto destroy_resource;
 

--- a/src/resources/tf_saved_model.c
+++ b/src/resources/tf_saved_model.c
@@ -209,7 +209,7 @@ int vaccel_tf_saved_model_set_model(
 	}
 
 	int ret = vaccel_file_from_buffer(&model->model, ptr, len,
-			NULL, false, NULL);
+			NULL, false, NULL, false);
 	return ret;
 }
 
@@ -253,7 +253,7 @@ int vaccel_tf_saved_model_set_checkpoint(
 	}
 
 	int ret = vaccel_file_from_buffer(&model->checkpoint, ptr, len,
-			NULL, false, NULL);
+			NULL, false, NULL, false);
 	return ret;
 }
 
@@ -297,7 +297,7 @@ int vaccel_tf_saved_model_set_var_index(
 	}
 
 	int ret = vaccel_file_from_buffer(&model->var_index, ptr, len,
-			NULL, false, NULL);
+			NULL, false, NULL, false);
 	return ret;
 }
 
@@ -373,17 +373,17 @@ int vaccel_tf_saved_model_register(struct vaccel_tf_saved_model *model)
 	}
 
 	ret = vaccel_file_persist(&model->model, res->rundir,
-			"saved_model.pb");
+			"saved_model.pb", false);
 	if (ret)
 		goto destroy_resource;
 
 	ret = vaccel_file_persist(&model->checkpoint, var_dir,
-			"variables.data-00000-of-00001");
+			"variables.data-00000-of-00001", false);
 	if (ret)
 		goto destroy_resource;
 
 	ret = vaccel_file_persist(&model->var_index, var_dir,
-			"variables.index");
+			"variables.index", false);
 	if (ret)
 		goto destroy_resource;
 


### PR DESCRIPTION
Commit fcfdcf6 (PR #75) broke tensorflow support as it randomizes the resource filename. Unfortunately, the filenames of the data in a TF saved model are hardcoded, so ... it wasn't working.

Also, update the 32-bit casting of the dims, to allow to build on 32-bit while keeping compatibility with a working TF example. 