### PR TITLE
session: add update API call

### DIFF
--- a/src/include/plugin.h
+++ b/src/include/plugin.h
@@ -97,6 +97,7 @@ struct vaccel_plugin_info {
 	/* In some cases, like in the context of VirtIO we need to offload
 	 * session handling to the plugin itself */
 	int (*sess_init)(struct vaccel_session *sess, uint32_t flags);
+	int (*sess_update)(struct vaccel_session *sess, uint32_t flags);
 	int (*sess_free)(struct vaccel_session *sess);
 	int (*sess_register)(uint32_t sess_id, vaccel_id_t resource_id);
 	int (*sess_unregister)(uint32_t sess_id, vaccel_id_t resource_id);

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -42,6 +42,9 @@ struct vaccel_session {
 /* Initialize a new session with the runtime */
 int vaccel_sess_init(struct vaccel_session *sess, uint32_t flags);
 
+/* Update a session with new flags */
+int vaccel_sess_update(struct vaccel_session *sess, uint32_t flags);
+
 /* Tear down a session */
 int vaccel_sess_free(struct vaccel_session *sess);
 

--- a/src/session.c
+++ b/src/session.c
@@ -264,6 +264,31 @@ cleanup_session:
 	return ret;
 }
 
+int vaccel_sess_update(struct vaccel_session *sess, uint32_t flags)
+{
+	if (!sess)
+		return VACCEL_EINVAL;
+
+	if (!sessions.initialized)
+		return VACCEL_ESESS;
+
+	/* if we're using virtio as a plugin offload the session update to the
+	 * host */
+	struct vaccel_plugin *virtio = get_virtio_plugin();
+	if (virtio) {
+		int ret = virtio->info->sess_update(sess, flags);
+		if (ret) {
+			vaccel_warn("Could not update host-side session");
+		}
+	} else {
+		sess->hint = flags;
+	}
+
+	vaccel_debug("session:%u update with flags: %u", sess->session_id, flags);
+
+	return VACCEL_OK;
+}
+
 int vaccel_sess_free(struct vaccel_session *sess)
 {
 	if (!sess)


### PR DESCRIPTION
Since we are using the flags field to provide the plugin hints, it makes sense to add an API call so that this hint is propagated to the relevant backends when running on a virtio setup.