### PR TITLE
Fix musl build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(BUILD_PLUGIN_EXEC "Build the exec plugin" OFF)
 option(BUILD_PLUGIN_NOOP "Build the no-op debugging plugin" OFF)
 option(BUILD_EXAMPLES "Build the examples" OFF)
 option(ENABLE_TESTS "Enable testing" OFF)
+option(MUSL_BUILD "Link against MUSL" OFF)
 
 # Export json with compile commands
 SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,20 +30,30 @@ set(BIN_EXAMPLES
 
 foreach(T ${BIN_EXAMPLES})
 	add_executable(${T} "${T}.c")
+	IF(MUSL_BUILD)
+	set_property(TARGET ${T} PROPERTY LINK_FLAGS "-Os")
+	ENDIF()
 	target_include_directories(${T} PRIVATE ${INCLUDE_DIRS})
+	IF(MUSL_BUILD)
+	set(CMAKE_FIND_LIBRARY_SUFFIXES .so)
+	ENDIF()
 	target_link_libraries(${T} PRIVATE vaccel dl)
 endforeach()
 
+IF(NOT MUSL_BUILD)
 add_executable(torch_inference "torch_inference.cpp")
 target_compile_options(torch_inference PUBLIC -fpermissive)
 target_include_directories(torch_inference PRIVATE ${INCLUDE_DIRS})
 target_link_libraries(torch_inference PRIVATE vaccel dl)
+ENDIF()
 
 add_library(mytestlib SHARED mytestlib.c)
 target_compile_options(mytestlib PUBLIC -Wall -Wextra )
 set_target_properties(mytestlib PROPERTIES ENABLE_EXPORTS on)
 
+IF(NOT MUSL_BUILD)
 install(TARGETS ${BIN_EXAMPLES} torch_inference DESTINATION ${CMAKE_INSTALL_BINDIR})
+ENDIF()
 install(TARGETS mytestlib DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Install misc files

--- a/examples/classify.c
+++ b/examples/classify.c
@@ -19,55 +19,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "common.h"
 #include <vaccel.h>
-
-int read_file(const char *filename, char **img, size_t *img_size)
-{
-	int fd;
-
-	fd = open(filename, O_RDONLY);
-	if (fd < 0) {
-		perror("open: ");
-		return 1;
-	}
-
-	struct stat info;
-	fstat(fd, &info);
-	fprintf(stdout, "Image size: %luB\n", info.st_size);
-
-	char *buf = malloc(info.st_size);
-	if (!buf) {
-		fprintf(stderr, "Could not allocate memory for image\n");
-		goto close_file;
-	}
-
-	long bytes = 0;
-	do {
-		int ret = read(fd, buf, info.st_size);
-		if (ret < 0) {
-			perror("Error while reading image: ");
-			goto free_buff;
-		}
-		bytes += ret;
-	} while (bytes < info.st_size);
-
-	if (bytes < info.st_size) {
-		fprintf(stderr, "Could not read image\n");
-		goto free_buff;
-	}
-
-	*img = buf;
-	*img_size = info.st_size;
-	close(fd);
-
-	return 0;
-
-free_buff:
-	free(buf);
-close_file:
-	close(fd);
-	return 1;
-}
 
 int main(int argc, char *argv[])
 {

--- a/examples/classify_generic.c
+++ b/examples/classify_generic.c
@@ -19,55 +19,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "common.h"
+
 #include <vaccel.h>
-
-int read_file(const char *filename, char **img, size_t *img_size)
-{
-	int fd;
-
-	fd = open(filename, O_RDONLY);
-	if (fd < 0) {
-		perror("open: ");
-		return 1;
-	}
-
-	struct stat info;
-	fstat(fd, &info);
-	fprintf(stdout, "Image size: %luB\n", info.st_size);
-
-	char *buf = malloc(info.st_size);
-	if (!buf) {
-		fprintf(stderr, "Could not allocate memory for image\n");
-		goto close_file;
-	}
-
-	long bytes = 0;
-	do {
-		int ret = read(fd, buf, info.st_size);
-		if (ret < 0) {
-			perror("Error while reading image: ");
-			goto free_buff;
-		}
-		bytes += ret;
-	} while (bytes < info.st_size);
-
-	if (bytes < info.st_size) {
-		fprintf(stderr, "Could not read image\n");
-		goto free_buff;
-	}
-
-	*img = buf;
-	*img_size = info.st_size;
-	close(fd);
-
-	return 0;
-
-free_buff:
-	free(buf);
-close_file:
-	close(fd);
-	return 1;
-}
 
 int main(int argc, char *argv[])
 {

--- a/examples/common.h
+++ b/examples/common.h
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+static int read_file(const char *filename, char **img, size_t *img_size)
+{
+	int fd;
+
+	fd = open(filename, O_RDONLY);
+	if (fd < 0) {
+		perror("open: ");
+		return 1;
+	}
+
+	struct stat info;
+	fstat(fd, &info);
+	fprintf(stdout, "Image size: %luB\n", info.st_size);
+
+	char *buf = malloc(info.st_size);
+	if (!buf) {
+		fprintf(stderr, "Could not allocate memory for image\n");
+		goto close_file;
+	}
+
+	long bytes = 0;
+	do {
+		int ret = read(fd, buf, info.st_size);
+		if (ret < 0) {
+			perror("Error while reading image: ");
+			goto free_buff;
+		}
+		bytes += ret;
+	} while (bytes < info.st_size);
+
+	if (bytes < info.st_size) {
+		fprintf(stderr, "Could not read image\n");
+		goto free_buff;
+	}
+
+	*img = buf;
+	*img_size = info.st_size;
+	close(fd);
+
+	return 0;
+
+free_buff:
+	free(buf);
+close_file:
+	close(fd);
+	return 1;
+}

--- a/examples/depth.c
+++ b/examples/depth.c
@@ -19,55 +19,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "common.h"
+
 #include <vaccel.h>
-
-int read_file(const char *filename, char **img, size_t *img_size)
-{
-	int fd;
-
-	fd = open(filename, O_RDONLY);
-	if (fd < 0) {
-		perror("open: ");
-		return 1;
-	}
-
-	struct stat info;
-	fstat(fd, &info);
-	fprintf(stdout, "Image size: %luB\n", info.st_size);
-
-	char *buf = malloc(info.st_size);
-	if (!buf) {
-		fprintf(stderr, "Could not allocate memory for image\n");
-		goto close_file;
-	}
-
-	long bytes = 0;
-	do {
-		int ret = read(fd, buf, info.st_size);
-		if (ret < 0) {
-			perror("Error while reading image: ");
-			goto free_buff;
-		}
-		bytes += ret;
-	} while (bytes < info.st_size);
-
-	if (bytes < info.st_size) {
-		fprintf(stderr, "Could not read image\n");
-		goto free_buff;
-	}
-
-	*img = buf;
-	*img_size = info.st_size;
-	close(fd);
-
-	return 0;
-
-free_buff:
-	free(buf);
-close_file:
-	close(fd);
-	return 1;
-}
 
 int main(int argc, char *argv[])
 {

--- a/examples/depth_generic.c
+++ b/examples/depth_generic.c
@@ -19,55 +19,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "common.h"
+
 #include <vaccel.h>
-
-int read_file(const char *filename, char **img, size_t *img_size)
-{
-	int fd;
-
-	fd = open(filename, O_RDONLY);
-	if (fd < 0) {
-		perror("open: ");
-		return 1;
-	}
-
-	struct stat info;
-	fstat(fd, &info);
-	fprintf(stdout, "Image size: %luB\n", info.st_size);
-
-	char *buf = malloc(info.st_size);
-	if (!buf) {
-		fprintf(stderr, "Could not allocate memory for image\n");
-		goto close_file;
-	}
-
-	long bytes = 0;
-	do {
-		int ret = read(fd, buf, info.st_size);
-		if (ret < 0) {
-			perror("Error while reading image: ");
-			goto free_buff;
-		}
-		bytes += ret;
-	} while (bytes < info.st_size);
-
-	if (bytes < info.st_size) {
-		fprintf(stderr, "Could not read image\n");
-		goto free_buff;
-	}
-
-	*img = buf;
-	*img_size = info.st_size;
-	close(fd);
-
-	return 0;
-
-free_buff:
-	free(buf);
-close_file:
-	close(fd);
-	return 1;
-}
 
 int main(int argc, char *argv[])
 {

--- a/examples/detect.c
+++ b/examples/detect.c
@@ -19,55 +19,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "common.h"
+
 #include <vaccel.h>
-
-int read_file(const char *filename, char **img, size_t *img_size)
-{
-	int fd;
-
-	fd = open(filename, O_RDONLY);
-	if (fd < 0) {
-		perror("open: ");
-		return 1;
-	}
-
-	struct stat info;
-	fstat(fd, &info);
-	fprintf(stdout, "Image size: %luB\n", info.st_size);
-
-	char *buf = malloc(info.st_size);
-	if (!buf) {
-		fprintf(stderr, "Could not allocate memory for image\n");
-		goto close_file;
-	}
-
-	long bytes = 0;
-	do {
-		int ret = read(fd, buf, info.st_size);
-		if (ret < 0) {
-			perror("Error while reading image: ");
-			goto free_buff;
-		}
-		bytes += ret;
-	} while (bytes < info.st_size);
-
-	if (bytes < info.st_size) {
-		fprintf(stderr, "Could not read image\n");
-		goto free_buff;
-	}
-
-	*img = buf;
-	*img_size = info.st_size;
-	close(fd);
-
-	return 0;
-
-free_buff:
-	free(buf);
-close_file:
-	close(fd);
-	return 1;
-}
 
 int main(int argc, char *argv[])
 {

--- a/examples/detect_generic.c
+++ b/examples/detect_generic.c
@@ -19,55 +19,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "common.h"
+
 #include <vaccel.h>
-
-int read_file(const char *filename, char **img, size_t *img_size)
-{
-	int fd;
-
-	fd = open(filename, O_RDONLY);
-	if (fd < 0) {
-		perror("open: ");
-		return 1;
-	}
-
-	struct stat info;
-	fstat(fd, &info);
-	fprintf(stdout, "Image size: %luB\n", info.st_size);
-
-	char *buf = malloc(info.st_size);
-	if (!buf) {
-		fprintf(stderr, "Could not allocate memory for image\n");
-		goto close_file;
-	}
-
-	long bytes = 0;
-	do {
-		int ret = read(fd, buf, info.st_size);
-		if (ret < 0) {
-			perror("Error while reading image: ");
-			goto free_buff;
-		}
-		bytes += ret;
-	} while (bytes < info.st_size);
-
-	if (bytes < info.st_size) {
-		fprintf(stderr, "Could not read image\n");
-		goto free_buff;
-	}
-
-	*img = buf;
-	*img_size = info.st_size;
-	close(fd);
-
-	return 0;
-
-free_buff:
-	free(buf);
-close_file:
-	close(fd);
-	return 1;
-}
 
 int main(int argc, char *argv[])
 {

--- a/examples/pose.c
+++ b/examples/pose.c
@@ -19,55 +19,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "common.h"
 #include <vaccel.h>
-
-int read_file(const char *filename, char **img, size_t *img_size)
-{
-	int fd;
-
-	fd = open(filename, O_RDONLY);
-	if (fd < 0) {
-		perror("open: ");
-		return 1;
-	}
-
-	struct stat info;
-	fstat(fd, &info);
-	fprintf(stdout, "Image size: %luB\n", info.st_size);
-
-	char *buf = malloc(info.st_size);
-	if (!buf) {
-		fprintf(stderr, "Could not allocate memory for image\n");
-		goto close_file;
-	}
-
-	long bytes = 0;
-	do {
-		int ret = read(fd, buf, info.st_size);
-		if (ret < 0) {
-			perror("Error while reading image: ");
-			goto free_buff;
-		}
-		bytes += ret;
-	} while (bytes < info.st_size);
-
-	if (bytes < info.st_size) {
-		fprintf(stderr, "Could not read image\n");
-		goto free_buff;
-	}
-
-	*img = buf;
-	*img_size = info.st_size;
-	close(fd);
-
-	return 0;
-
-free_buff:
-	free(buf);
-close_file:
-	close(fd);
-	return 1;
-}
 
 int main(int argc, char *argv[])
 {

--- a/examples/pose_generic.c
+++ b/examples/pose_generic.c
@@ -19,55 +19,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "common.h"
+
 #include <vaccel.h>
-
-int read_file(const char *filename, char **img, size_t *img_size)
-{
-	int fd;
-
-	fd = open(filename, O_RDONLY);
-	if (fd < 0) {
-		perror("open: ");
-		return 1;
-	}
-
-	struct stat info;
-	fstat(fd, &info);
-	fprintf(stdout, "Image size: %luB\n", info.st_size);
-
-	char *buf = malloc(info.st_size);
-	if (!buf) {
-		fprintf(stderr, "Could not allocate memory for image\n");
-		goto close_file;
-	}
-
-	long bytes = 0;
-	do {
-		int ret = read(fd, buf, info.st_size);
-		if (ret < 0) {
-			perror("Error while reading image: ");
-			goto free_buff;
-		}
-		bytes += ret;
-	} while (bytes < info.st_size);
-
-	if (bytes < info.st_size) {
-		fprintf(stderr, "Could not read image\n");
-		goto free_buff;
-	}
-
-	*img = buf;
-	*img_size = info.st_size;
-	close(fd);
-
-	return 0;
-
-free_buff:
-	free(buf);
-close_file:
-	close(fd);
-	return 1;
-}
 
 int main(int argc, char *argv[])
 {

--- a/examples/segment.c
+++ b/examples/segment.c
@@ -19,55 +19,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "common.h"
+
 #include <vaccel.h>
-
-int read_file(const char *filename, char **img, size_t *img_size)
-{
-	int fd;
-
-	fd = open(filename, O_RDONLY);
-	if (fd < 0) {
-		perror("open: ");
-		return 1;
-	}
-
-	struct stat info;
-	fstat(fd, &info);
-	fprintf(stdout, "Image size: %luB\n", info.st_size);
-
-	char *buf = malloc(info.st_size);
-	if (!buf) {
-		fprintf(stderr, "Could not allocate memory for image\n");
-		goto close_file;
-	}
-
-	long bytes = 0;
-	do {
-		int ret = read(fd, buf, info.st_size);
-		if (ret < 0) {
-			perror("Error while reading image: ");
-			goto free_buff;
-		}
-		bytes += ret;
-	} while (bytes < info.st_size);
-
-	if (bytes < info.st_size) {
-		fprintf(stderr, "Could not read image\n");
-		goto free_buff;
-	}
-
-	*img = buf;
-	*img_size = info.st_size;
-	close(fd);
-
-	return 0;
-
-free_buff:
-	free(buf);
-close_file:
-	close(fd);
-	return 1;
-}
 
 int main(int argc, char *argv[])
 {

--- a/examples/segment_generic.c
+++ b/examples/segment_generic.c
@@ -19,55 +19,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "common.h"
+
 #include <vaccel.h>
-
-int read_file(const char *filename, char **img, size_t *img_size)
-{
-	int fd;
-
-	fd = open(filename, O_RDONLY);
-	if (fd < 0) {
-		perror("open: ");
-		return 1;
-	}
-
-	struct stat info;
-	fstat(fd, &info);
-	fprintf(stdout, "Image size: %luB\n", info.st_size);
-
-	char *buf = malloc(info.st_size);
-	if (!buf) {
-		fprintf(stderr, "Could not allocate memory for image\n");
-		goto close_file;
-	}
-
-	long bytes = 0;
-	do {
-		int ret = read(fd, buf, info.st_size);
-		if (ret < 0) {
-			perror("Error while reading image: ");
-			goto free_buff;
-		}
-		bytes += ret;
-	} while (bytes < info.st_size);
-
-	if (bytes < info.st_size) {
-		fprintf(stderr, "Could not read image\n");
-		goto free_buff;
-	}
-
-	*img = buf;
-	*img_size = info.st_size;
-	close(fd);
-
-	return 0;
-
-free_buff:
-	free(buf);
-close_file:
-	close(fd);
-	return 1;
-}
 
 int main(int argc, char *argv[])
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ file(GLOB_RECURSE sources *.c)
 file(GLOB_RECURSE headers *.h)
 
 add_library(vaccel SHARED ${headers} ${sources})
+
 target_compile_options(vaccel PUBLIC -Wall -Wextra -Werror -pthread)
 target_include_directories(vaccel PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(vaccel PRIVATE ${CMAKE_SOURCE_DIR}/src/include)
@@ -12,6 +13,9 @@ target_include_directories(vaccel PRIVATE ${CMAKE_BINARY_DIR})
 
 target_include_directories(vaccel PRIVATE ${CMAKE_SOURCE_DIR}/src/include)
 set_property(TARGET vaccel PROPERTY LINK_FLAGS "-pthread")
+IF(MUSL_BUILD)
+set_property(TARGET vaccel PROPERTY LINK_FLAGS "-Os -pthread")
+ENDIF()
 set_property(TARGET vaccel PROPERTY C_STANDARD 11)
 target_link_libraries(vaccel slog)
 

--- a/src/profiling/vaccel_prof.c
+++ b/src/profiling/vaccel_prof.c
@@ -18,6 +18,7 @@
 #include "error.h"
 
 #include <malloc.h>
+#include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <stddef.h>


### PR DESCRIPTION
it seems we need to explicitly include `stdio.h` for vaccelrt to built correctly using musl.

```
export CC="musl-gcc"
mkdir build && cd build
cmake -DCMAKE_EXE_LINKER_FLAGS="-static -Os" ..
make
```

```
$ musl-ldd src/libvaccel.so
	musl-ldd (0x7fef4be96000)
	libc.so => musl-ldd (0x7fef4be96000)
```