### PR TITLE
ci: re-enable tf test

### DIFF
--- a/.github/workflows/test_vaccelrt.yml
+++ b/.github/workflows/test_vaccelrt.yml
@@ -96,6 +96,9 @@ jobs:
         ./bin/pynq_array_copy
         ./bin/pynq_parallel
         ./bin/torch_inference ./share/images/example.jpg ./share/models/torch
+        ./bin/tf_model share/models/tf/frozen_graph.pb
+        ./bin/tf_saved_model share/models/tf/lstm2
+        ./bin/tf_inference share/models/tf/lstm2
 
     - name: Upload binary distr to s3
       uses: cloudkernels/minio-upload@v4


### PR DESCRIPTION
Seems like the buffered `fwrite()` fix resolves the tf issue. Re-enable the tf test with noop.