### PR TITLE
vaccel_args: Introduce helper functions for vAccel arguments

### DIFF
--- a/.github/workflows/test_vaccelrt.yml
+++ b/.github/workflows/test_vaccelrt.yml
@@ -65,7 +65,8 @@ jobs:
         cd build_${{matrix.build_type}}
         cmake ${{github.workspace}} \
           -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/artifacts/${{matrix.archconfig}}/${{matrix.build_type}}/opt \
-          -DBUILD_PLUGIN_NOOP=ON && \
+          -DBUILD_PLUGIN_NOOP=ON \
+          -DBUILD_PLUGIN_EXEC=ON && \
         make -C plugins && make install -C plugins
 
     - name: Run examples
@@ -100,14 +101,19 @@ jobs:
         ./bin/tf_saved_model share/models/tf/lstm2
         ./bin/tf_inference share/models/tf/lstm2
 
-    - name: Upload binary distr to s3
-      uses: cloudkernels/minio-upload@v4
-      with:
-        url: https://s3.nubificus.co.uk
-        access-key: ${{ secrets.AWS_ACCESS_KEY }}
-        secret-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        local-path: artifacts/${{ matrix.archconfig }}/${{ matrix.build_type }}/opt
-        remote-path: nbfc-assets/github/vaccelrt/${{ env.ARTIFACT_SHA }}/${{ matrix.archconfig }}/${{ matrix.build_type }}/
+    - name: Run exec examples
+      id: run_exec_examples
+      env:
+        LD_LIBRARY_PATH: ${{github.workspace}}/artifacts/${{matrix.archconfig}}/${{matrix.build_type}}/opt/lib
+        VACCEL_BACKENDS: ${{github.workspace}}/artifacts/${{matrix.archconfig}}/${{matrix.build_type}}/opt/lib/libvaccel-exec.so
+        VACCEL_DEBUG_LEVEL: 4
+      run: |
+        cd ${{github.workspace}}/artifacts/${{matrix.archconfig}}/${{matrix.build_type}}/opt
+        #sudo mkdir -p /run/user/1001
+        #sudo chown -R runner /run/user/1001
+        ./bin/exec_with_res lib/libmytestlib.so 1
+        ./bin/exec_helpers lib/libmytestlib.so 1
+        ./bin/exec_helpers_nonser lib/libmytestlib.so 1
 
     - name: Build project for packages
       id: build_pkg_vaccelrt

--- a/docs/vaccel_args.md
+++ b/docs/vaccel_args.md
@@ -1,0 +1,246 @@
+# How to pass arguments when running a vAccel operation
+When running an operation in vAccel, we would probably provide some input and expect some output:
+```c
+ret = vaccel_op( ..., <read args>, <num_read>, <write args>, <num_write>);
+```
+Each argument is passed to the operation using the following structure:
+```c
+struct vaccel_arg {
+	uint32_t argtype;
+	uint32_t size;
+	void *buf;
+};
+```
+
+If we are not willing to pass each of the arguments by hand, we could use the structure below:
+
+```c
+struct vaccel_arg_list;
+```
+which can be initialized with the function:
+
+```c
+vaccel_args_init()
+```
+For example, in case that we want to pass both input and output arguments, we should initialize two instances of that structure like that:
+
+```c
+struct vaccel_arg_list* read   = vaccel_args_init(<NUM_ARGS>);
+struct vaccel_arg_list* write  = vaccel_args_init(<NUM_ARGS>);
+```
+
+## Main Program
+### Add an input argument 
+Let's say we want to call an operation with two input arguments. One integer and one other kind of structure which is not already serialized (eg a struct that contains pointers)
+
+#### Already serialized
+In the first case, we simply define the address in which our input is located. For example:
+```c
+int input = ...;
+ret = vaccel_add_serial_arg(read, &input, sizeof(input));
+if (ret != VACCEL_OK) {
+  /* A problem occured */
+}
+```
+#### Non-serialized
+However, in case that our argument is not serialized, we can't use the previous function. For example, we may need to pass as an argument a struct that contains pointers. For instance, the following structure:
+ ```c
+struct mydata
+{
+	uint32_t size;
+	int* array;
+};
+ ```
+ 
+ Unfortunately, it's meaningless to transfer such data remotely, since the pointers won't have any sense to a **different address space**. For that reason, we have to serialize that data before it's used. Actually, we can use ```vaccel_add_nonserial_arg()``` and provide a function that will serialize the data. That function must have the following signature:
+```c
+void* serializer(void*, uint32_t*);
+```
+
+And the rationale of its functionality:
+
+```c
+void* serializer(void *nonserial_buf, uint32_t* bytes){
+
+  /* Read the structure */
+  struct mydata *input = (struct mydata*) nonserial_buf;
+
+  /* Allocate space for the serialized buffer */
+  void *serial_mydata = ... ;
+
+
+ /*
+  * Process `input` in order to create a serialized  
+  * form of `mydata`, and write it to `serial_mydata`
+  */
+
+
+  /* Provide the size of the serialized data */
+  *bytes = ... ;
+
+  /* `serial_mydata` now contains raw data */
+  return serial_mydata;
+}
+```
+
+Afterwards, we can use the above function like that:
+```c
+struct mydata arg_mydata= init_mydata();
+uint32_t type = 0;
+ret = vaccel_add_nonserial_arg(read, &arg_mydata, type, serializer);
+if (ret != VACCEL_OK) {
+  /* A problem occured */
+}
+```
+
+### Add output arguments
+Now, since we may expect by the operation to return some output, we should provide some space in which they will be written:
+
+#### Already serialized
+In case we expect to get back a float, we simply add the following command:
+```c
+float out;
+ret = vaccel_expect_serial_arg(write, &out, sizeof(out));
+if (ret != VACCEL_OK) {
+  /* A problem occured */
+}
+```
+#### Non-serialized
+Similarly, we call the corresponding function for non-serialized arguments. However we don't define any buffer, because the returned data will be meaningless after the operation ends, since it won't have been deserialized yet. Later (after calling the operation), we can ask for the output using their indeces, along with a deserializer function. We also provide the size of the expected output as a parameter.
+
+Let's assume that we expect an instance of ```struct mydata```. We just run:
+```c
+uint32_t expected_size = ... ;
+ret = vaccel_expect_nonserial_arg(write, expected_size);
+if (ret != VACCEL_OK) {
+  /* A problem occured */
+}
+```
+As you can see we did't define the type of the output, since it will be raw data, prior to its deserialization.
+
+### Run the operation
+Since we have prepared our arguments, we can call the operation like that:
+```c
+ret = vaccel_op( ..., read->list, read->size, write->list, write->size);
+```
+### Read the output arguments
+After the operation returns, we can ask for the output using the "**extract**" functions.
+
+#### Already serialized
+For serialized data (i.e. the float we expect) we have direct access by the buffer we provided:
+```c
+float ret_val = out;
+```
+However, we can also ask for that location by calling:
+```c
+float *outptr = vaccel_extract_serial_arg(write->list, 0);
+/* where 0 is the index of our output */
+```
+
+#### Non-serialized
+On the other hand, for non-serialized output, we cannot just ask for the value, since the returned data has been serialized. Thus, we provide a deserializer function to retrieve the structure. This deserializer must have the following signature:
+
+```c
+void* deserializer(void*, uint32_t);
+```
+And the rationale of its functionality:
+```c
+void* deserializer(void* serial_buf, uint32_t bytes){
+  
+  /* Allocate space for the structure */
+  struct mydata *new_mydata = ... ;
+
+  
+  /* 
+   * Process `serial_buf` in order to retrieve  
+   * the real data and write it to `new_mydata`
+   */
+   
+
+  /* new_mydata now contains the retrieved structure */
+  return new_mydata;
+}
+```
+And we use it like this:
+```c
+struct mydata *outbuf;
+outbuf = vaccel_extract_nonserial_arg(write->list, 1, deserializer);
+/* where 1 is the index on the arguments' list */
+/* the memory that `outbuf` points to, must be freed later */
+```
+**It's up to the user to free the memory that vaccel_extract_nonserial_arg() returns**
+
+### Clean the memory
+
+Finally, we can clean the memory that was allocated by the argument lists by running:
+```c
+ret = vaccel_delete_args(read);
+if (ret != VACCEL_OK) {
+  /* A problem occured */
+}
+
+ret = vaccel_delete_args(write);
+if (ret != VACCEL_OK) {
+  /* A problem occured */
+}
+```
+## Plugin
+
+Inside the plugin, we want to read the input, process it and return the result back to the main program.
+
+### Read the arguments 
+The "**extract**" functions that were previously used, will be used again to receive the input. The rationale remains the same.
+
+#### Already serialized
+```c
+static int plugin_func(struct vaccel_arg *read,
+        size_t nr_read, struct vaccel_arg *write, size_t nr_write){
+
+  /* we expect an integer at index 0 */
+  int *input = vaccel_extract_serial_arg(read->list, 0);
+
+  ...
+}
+```
+
+#### Non-serialized
+```c
+static int plugin_func(struct vaccel_arg *read,
+        size_t nr_read, struct vaccel_arg *write, size_t nr_write){
+
+  ...
+
+  /* we also expect an instance of "mydata" at index 1 */
+  struct mydata *inbuf;
+  inbuf = vaccel_extract_nonserial_arg(read->list, 1, deserializer);
+
+  ...
+}
+```
+**The address returned by vaccel_extract_nonserial_arg() contains allocated memory. It must be freed after the data is read.**
+
+### Write to output arguments
+Finally, we want to write the response of the plugin to the buffers that were previously defined. For that reason we use the "**write**" functions
+#### Already serialized
+Since the user defined that expects to receive a float at index 0, we can provide the value with the following function:
+```c
+...
+float response = ...;
+ret = vaccel_write_serial_arg(write->list, 0, &response);
+if (ret != VACCEL_OK) {
+  /* A problem occured */
+}
+...
+```
+#### Non-serialized
+
+Similarly, it was also defined that a non-serialized structure will be received at index 1. So:
+```c
+...
+struct mydata out = ...;
+ret = vaccel_write_nonserial_arg(write->list, 1, &out, serializer);
+if (ret != VACCEL_OK) {
+  /* A problem occured */
+}
+...
+```

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -26,7 +26,9 @@ set(BIN_EXAMPLES
 	pynq_parallel
 	pynq_parallel_generic
 	pynq_array_copy
-	pynq_array_copy_generic)
+	pynq_array_copy_generic
+	exec_helpers
+	exec_helpers_nonser)
 
 foreach(T ${BIN_EXAMPLES})
 	add_executable(${T} "${T}.c")
@@ -41,6 +43,7 @@ target_link_libraries(torch_inference PRIVATE vaccel dl)
 
 add_library(mytestlib SHARED mytestlib.c)
 target_compile_options(mytestlib PUBLIC -Wall -Wextra )
+target_include_directories(mytestlib PRIVATE ${INCLUDE_DIRS})
 set_target_properties(mytestlib PROPERTIES ENABLE_EXPORTS on)
 
 install(TARGETS ${BIN_EXAMPLES} torch_inference DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/examples/exec.c
+++ b/examples/exec.c
@@ -26,7 +26,7 @@ int main(int argc, char *argv[])
 	int ret;
 	struct vaccel_session sess;
 	int input;
-	char out_text[512];
+	int output;
 
 	if (argc < 2) {
 		fprintf(stderr, "You must specify the number of iterations\n");
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
 		{.size = sizeof(input),.buf = &input}
 	};
 	struct vaccel_arg write[1] = {
-		{.size = sizeof(out_text),.buf = out_text},
+		{.size = sizeof(output),.buf = &output},
 	};
 
 	//vaccel_get_plugins(&sess, 7);
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
 			goto close_session;
 		}
 	}
-	printf("output: %s\n", out_text);
+	printf("output(2x%d): %d\n", input, output);
 
  close_session:
 	if (vaccel_sess_free(&sess) != VACCEL_OK) {

--- a/examples/exec_generic.c
+++ b/examples/exec_generic.c
@@ -27,7 +27,7 @@ int main(int argc, char **argv)
 	int ret;
 	struct vaccel_session sess;
 	int input;
-	char out_text[512];
+	int output;
 
 	if (argc < 2) {
 		fprintf(stderr, "You must specify the number of iterations\n");
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
 		{.size = sizeof(input),.buf = &input}
 	};
 	struct vaccel_arg write[1] = {
-		{.size = sizeof(out_text),.buf = out_text},
+		{.size = sizeof(output),.buf = &output},
 	};
 
 	for (int i = 0; i < atoi(argv[1]); ++i) {
@@ -61,7 +61,8 @@ int main(int argc, char **argv)
 			goto close_session;
 		}
 	}
-	printf("output: %s\n", out_text);
+	
+	printf("output(2x%d): %d\n", input, output);
 
  close_session:
 	if (vaccel_sess_free(&sess) != VACCEL_OK) {

--- a/examples/exec_helpers.c
+++ b/examples/exec_helpers.c
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <vaccel.h>
+
+int main(int argc, char *argv[])
+{
+	int ret;
+	struct vaccel_session sess;
+	int input_int;
+	int output_int;
+	struct vaccel_shared_object object;
+
+	if (argc < 2) {
+		fprintf(stderr, "You must specify the number of iterations\n");
+		return 1;
+	}
+
+	ret = vaccel_shared_object_new(&object, argv[1]);
+        if (ret)
+        {
+                fprintf(stderr, "Could not create shared object resource: %s",
+                                strerror(ret));
+                exit(1);
+        }
+	sess.hint = VACCEL_PLUGIN_DEBUG;
+	ret = vaccel_sess_init(&sess, sess.hint);
+	if (ret != VACCEL_OK) {
+		fprintf(stderr, "Could not initialize session\n");
+		return 1;
+	}
+
+	printf("Initialized session with id: %u\n", sess.session_id);
+
+	ret = vaccel_sess_register(&sess, object.resource);
+	if (ret)
+	{
+		fprintf(stderr, "Could register shared object to session\n");
+		exit(1);
+	}
+
+	printf("Initialized session with id: %u\n", sess.session_id);
+
+	
+	struct vaccel_arg_list* read  = vaccel_args_init(1);
+	struct vaccel_arg_list* write = vaccel_args_init(1);
+
+	if (!read || !write) {
+		printf("Problem with creating arg-list\n");
+		return 1;
+	}
+
+	input_int = 15;
+	ret = vaccel_add_serial_arg(read, &input_int, sizeof(input_int));
+	if (ret != VACCEL_OK) {
+		printf("Could not add serialized arg\n");
+		return 1;
+	}
+
+	ret = vaccel_expect_serial_arg(write, &output_int, sizeof(output_int));
+	if (ret != VACCEL_OK) {
+		printf("Could not define expected serialized arg\n");
+		return 1;
+	}
+
+	for (int i = 0; i < atoi(argv[2]); ++i) {
+		ret =
+		    vaccel_exec_with_resource(&sess, &object,
+				"mytestfunc", 
+				read->list, read->size, 
+				write->list, write->size);
+		
+		if (ret) {
+			fprintf(stderr, "Could not run op: %d\n", ret);
+			goto close_session;
+		}
+	}
+
+	int *outptr = vaccel_extract_serial_arg(write->list, 0);
+	if (!outptr) {
+		printf("Could not extract serialized arg\n");
+		return 1;
+	}
+
+	printf("input     : %d\n", input_int);
+	printf("output(2x): %d\n", *outptr);
+	printf("output(2x): %d\n", output_int);
+
+ close_session:
+	
+	ret = vaccel_delete_args(read);
+	if (ret != VACCEL_OK) {
+		printf("Could not delete arg list\n");
+		return 1;
+	}
+
+	ret = vaccel_delete_args(write);
+	if (ret != VACCEL_OK) {
+		printf("Could not delete arg list\n");
+		return 1;
+	}
+
+	ret = vaccel_sess_unregister(&sess, object.resource);
+	if (ret) {
+		fprintf(stderr, "Could not unregister object from session\n");
+		exit(1);
+	}
+
+	if (vaccel_sess_free(&sess) != VACCEL_OK) {
+		fprintf(stderr, "Could not clear session\n");
+		return 1;
+	}
+
+	ret = vaccel_shared_object_destroy(&object);
+	if (ret) {
+		fprintf(stderr, "Could not destroy object\n");
+		exit(1);
+	}
+
+	return ret;
+}

--- a/examples/exec_helpers_nonser.c
+++ b/examples/exec_helpers_nonser.c
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <vaccel.h>
+
+struct mydata
+{
+	uint32_t size;
+	int* array;
+};
+
+/* Serializer function for `struct mydata` */
+void* ser(void* buf, uint32_t* bytes){
+	struct mydata* non_ser = (struct mydata*)buf;
+
+	uint32_t size = (non_ser->size + 1) * sizeof(int);
+	int* ser_buf = malloc(size);
+
+	memcpy(ser_buf, (int*)(&non_ser->size), sizeof(int));
+
+	uint32_t i;
+	for(i = 0; i < non_ser->size; i++)
+		memcpy(&ser_buf[i+1], &non_ser->array[i], sizeof(int));
+
+	*bytes = size;
+	return ser_buf;
+}
+
+/* Deserializer function for `struct mydata` */
+void* deser(void* buf, uint32_t __attribute__((unused)) bytes){
+	int *ser_buf = (int*)buf;
+	int size = ser_buf[0];
+
+	if (!size)
+		return NULL;
+
+	struct mydata* new_buf = 
+		(struct mydata*)malloc(sizeof(struct mydata));
+
+	new_buf->size = (uint32_t)size;
+	new_buf->array = malloc(new_buf->size * sizeof(int));
+	for(int i=0; i<size; i++)
+		memcpy(&new_buf->array[i], &ser_buf[i+1], sizeof(int));
+
+	return new_buf;
+}
+
+int main(int argc, char *argv[])
+{
+	int ret;
+	struct vaccel_session sess;
+	struct vaccel_shared_object object;
+
+	struct mydata input_data;
+	struct mydata* output_data = NULL;
+
+	if (argc < 3) {
+		fprintf(stderr, "You must specify the number of iterations\n");
+		return 1;
+	}
+
+	ret = vaccel_shared_object_new(&object, argv[1]);
+        if (ret)
+        {
+                fprintf(stderr, "Could not create shared object resource: %s",
+                                strerror(ret));
+                exit(1);
+        }
+	sess.hint = VACCEL_PLUGIN_DEBUG;
+	ret = vaccel_sess_init(&sess, sess.hint);
+	if (ret != VACCEL_OK) {
+		fprintf(stderr, "Could not initialize session\n");
+		return 1;
+	}
+
+	printf("Initialized session with id: %u\n", sess.session_id);
+
+	ret = vaccel_sess_register(&sess, object.resource);
+	if (ret)
+	{
+		fprintf(stderr, "Could register shared object to session\n");
+		exit(1);
+	}
+
+	struct vaccel_arg_list* read  = vaccel_args_init(1);
+	struct vaccel_arg_list* write = vaccel_args_init(1);
+
+	if (!read || !write) {
+		printf("Problem with creating arg-list\n");
+		return 1;
+	}
+
+	input_data.size = 5;
+	input_data.array = malloc(5*sizeof(int));
+	printf("Input: ");
+	for(int i=0; i<5; i++){
+		input_data.array[i] = 2*i;
+		printf("%d ", input_data.array[i]);
+	}
+	printf("\n");
+
+
+	ret = vaccel_add_nonserial_arg(read, &input_data, 0, ser);
+	if (ret != VACCEL_OK) {
+		printf("Could not add non-serialized arg\n");
+		return 1;
+	}
+
+	uint32_t expected_size = (input_data.size + 1) * sizeof(int);
+	ret = vaccel_expect_nonserial_arg(write, expected_size);
+	if (ret != VACCEL_OK) {
+		printf("Could not define expected non-serialized arg\n");
+		return 1;
+	}
+
+	for (int i = 0; i < atoi(argv[2]); ++i) {
+		ret =
+		    vaccel_exec_with_resource(&sess, &object,
+				"mytestfunc_nonser",
+				read->list, read->size,
+				write->list, write->size);
+
+		if (ret) {
+			fprintf(stderr, "Could not run op: %d\n", ret);
+			goto close_session;
+		}
+	}
+
+	output_data = vaccel_extract_nonserial_arg(write->list, 0, deser);
+	if (!output_data) {
+		printf("Could not extract non-serialized arg\n");
+		return 1;
+	}
+
+	printf("Output: ");
+	uint32_t i;
+	for(i = 0; i < output_data->size; i++){
+		printf("%d ", output_data->array[i]);
+	}
+	printf("\n");
+
+ close_session:
+
+	/* Free non-serialised buffers */ 
+	free(input_data.array);
+	free(output_data->array);
+	free(output_data);
+
+	/* Delete arg-lists */ 
+	ret = vaccel_delete_args(read);
+	if (ret != VACCEL_OK) {
+		printf("Could not delete arg list\n");
+		return 1;
+	}
+
+	ret = vaccel_delete_args(write);
+	if (ret != VACCEL_OK) {
+		printf("Could not delete arg list\n");
+		return 1;
+	}
+
+	ret = vaccel_sess_unregister(&sess, object.resource);
+	if (ret) {
+		fprintf(stderr, "Could not unregister object from session\n");
+		exit(1);
+	}
+
+	if (vaccel_sess_free(&sess) != VACCEL_OK) {
+		fprintf(stderr, "Could not clear session\n");
+		return 1;
+	}
+
+	ret = vaccel_shared_object_destroy(&object);
+	if (ret) {
+		fprintf(stderr, "Could not destroy object\n");
+		exit(1);
+	}
+
+	return ret;
+}

--- a/examples/exec_with_res.c
+++ b/examples/exec_with_res.c
@@ -81,8 +81,8 @@ int main(int argc, char *argv[])
 	}
 
 	int input;
-	char out_text[512];
-	char out_text2[512];
+	int output1;
+	int output2;
 
 	struct vaccel_shared_object object;
 
@@ -135,9 +135,10 @@ int main(int argc, char *argv[])
 
 	input = 10; /* some random input value */
 	struct vaccel_arg read[1] = {
-		{.size = sizeof(input), .buf = &input}};
+		{.size = sizeof(input), .buf = &input, .argtype = 42}
+	};
 	struct vaccel_arg write[1] = {
-		{.size = sizeof(out_text), .buf = out_text},
+		{.size = sizeof(output1), .buf = &output1, .argtype = 42},
 	};
 
 	for (int i = 0; i < atoi(argv[2]); ++i)
@@ -149,12 +150,12 @@ int main(int argc, char *argv[])
 			goto close_session;
 		}
 	}
-	printf("output: %s\n", out_text);
+	printf("output1(2x%d): %d\n", input, output1);
 
 	struct vaccel_arg read_2[1] = {
 		{.size = sizeof(input), .buf = &input}};
 	struct vaccel_arg write_2[1] = {
-		{.size = sizeof(out_text2), .buf = out_text2},
+		{.size = sizeof(output2), .buf = &output2},
 	};
 
 	for (int i = 0; i < atoi(argv[2]); ++i)
@@ -167,7 +168,7 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	printf("output: %s\n", out_text2);
+	printf("output1(2x%d): %d\n", input, output2);
 	ret = vaccel_sess_unregister(&sess, object.resource);
 	if (ret) {
 		fprintf(stderr, "Could not unregister object from session\n");

--- a/examples/mytestlib.c
+++ b/examples/mytestlib.c
@@ -22,23 +22,107 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-struct vaccel_arg {
-	uint32_t len;
-	void *buf;
+#include <vaccel.h>
+
+struct mydata
+{
+	uint32_t size;
+	int* array;
 };
+
+/* Serializer function for `struct mydata` */
+void* ser(void* buf, uint32_t* bytes){
+	struct mydata* non_ser = (struct mydata*)buf;
+
+	uint32_t size = (non_ser->size + 1) * sizeof(int);
+	int* ser_buf = malloc(size);
+
+	memcpy(ser_buf, (int*)(&non_ser->size), sizeof(int));
+
+	for(int i=0; i<(int)non_ser->size; i++)
+		memcpy(&ser_buf[i+1], &non_ser->array[i], sizeof(int));
+
+
+	*bytes = size;
+	return ser_buf;
+}
+
+/* Deserializer function for `struct mydata` */
+void* deser(void* buf, uint32_t __attribute__((unused)) bytes){
+	int *ser_buf = (int*)buf;
+	int size = ser_buf[0];
+
+	struct mydata* new_buf =
+		(struct mydata*)malloc(sizeof(struct mydata));
+
+	new_buf->size = (uint32_t)size;
+	new_buf->array = malloc(new_buf->size * sizeof(int));
+	for(int i=0; i<size; i++)
+		memcpy(&new_buf->array[i], &ser_buf[i+1], sizeof(int));
+
+	return new_buf;
+}
 
 /* We know we're getting only one read and only one write argument */
 
+/* Test function for serialized data */
 int mytestfunc(struct vaccel_arg *input, size_t nr_in,
 	       struct vaccel_arg *output, size_t nr_out)
 {
-	int a = *(int *)input[0].buf;
+	assert(nr_in >= 1);
+	assert(nr_out >= 1);
+
+	/* Input */
+	int* input_int = vaccel_extract_serial_arg(input, 0);
+	
+	printf("I got nr_in: %ld, nr_out: %ld\n", nr_in, nr_out);
+	printf("I got this input: %d\n", *input_int);
+
+	/* Output */
+	int output_int = 2*(*input_int);
+	vaccel_write_serial_arg(output, 0, &output_int);
+	return 0;
+}
+
+/* Test function for non-serialized data */
+int mytestfunc_nonser(struct vaccel_arg *input, size_t nr_in,
+	       struct vaccel_arg *output, size_t nr_out)
+{
 	assert(nr_in >= 1);
 	assert(nr_out >= 1);
 	printf("I got nr_in: %ld, nr_out: %ld\n", nr_in, nr_out);
-	printf("I got this input: %d\n", a);
-	sprintf(output[0].buf, "I got this input: %d\n", a);
-	output[0].len = strlen(output[0].buf);
+
+	/* Input */
+	struct mydata* input_data =
+		vaccel_extract_nonserial_arg(input, 0, deser);
+
+	if (!input_data) {
+		printf("Could not extract non-serialized arg\n");
+		return 1;
+	}
+
+	/* Copy the numbers */
+	int *numbuf = malloc(input_data->size*sizeof(int));
+	memcpy(numbuf, input_data->array, input_data->size * sizeof(int));
+	
+	/* Reverse the numbers */
+	for(int i=0; i<(int)input_data->size; i++){
+		input_data->array[i] = numbuf[input_data->size - i - 1];
+	}
+
+	/* Output */
+	struct mydata* output_data = input_data;
+	int ret = vaccel_write_nonserial_arg(output, 0, output_data, ser);
+	
+	if (ret != VACCEL_OK) {
+		printf("Could not write to non-serialized arg\n");
+		return 1;
+	}
+
+	/* Free Memory */
+	free(output_data->array);
+	free(output_data);
+	free(numbuf);
 
 	return 0;
 }

--- a/plugins/exec/vaccel.c
+++ b/plugins/exec/vaccel.c
@@ -54,6 +54,18 @@ static int exec(struct vaccel_session *session, const char *library, const char
 
 	/* Get the function pointer based on the relevant symbol */
 	vaccel_debug("[exec] symbol: %s", fn_symbol);
+
+	args = (struct vaccel_arg*) read;
+	for (i = 0 ; i<nr_read;i++) {
+		vaccel_debug("[exec]: read[%d].size: %u\n", i, args[i].size);
+		vaccel_debug("[exec]: read[%d].argtype: %u\n", i, args[i].argtype);
+	}
+	args = (struct vaccel_arg*) write;
+	for (i = 0 ; i<nr_write;i++) {
+		vaccel_debug("[exec]: write[%d].size: %u\n", i, args[i].size);
+		vaccel_debug("[exec]: write[%d].argtype: %u\n", i, args[i].argtype);
+	}
+
 	fptr = (int (*)(void*, size_t, void*,size_t))dlsym(dl, fn_symbol);
 	if (!fptr) {
 		vaccel_error("%s", dlerror());
@@ -99,6 +111,16 @@ static int exec_with_resource(struct vaccel_session *session, struct vaccel_shar
 		return VACCEL_EINVAL;
 	}
 
+	args = (struct vaccel_arg*) read;
+	for (i = 0 ; i<nr_read;i++) {
+		vaccel_debug("[exec]: read[%d].size: %u\n", args[i].size);
+		vaccel_debug("[exec]: read[%d].argtype: %u\n", args[i].argtype);
+	}
+	args = (struct vaccel_arg*) write;
+	for (i = 0 ; i<nr_write;i++) {
+		vaccel_debug("[exec]: write[%d].size: %u\n", args[i].size);
+		vaccel_debug("[exec]: write[%d].argtype: %u\n", args[i].argtype);
+	}
 	ret = (*fptr)(read, nr_read, write, nr_write);
 	if (ret)
 		return VACCEL_ENOEXEC;

--- a/src/include/vaccel_args.h
+++ b/src/include/vaccel_args.h
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __INCLUDE_VACCEL_ARGS_H__
+#define __INCLUDE_VACCEL_ARGS_H__
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "error.h"
+
+struct vaccel_arg {
+	uint32_t argtype;
+
+	uint32_t size;
+
+	void *buf;
+};
+
+struct vaccel_arg_list {
+
+    /* total size of the list */
+    uint32_t size;
+
+    /* pointer to the entries of the list*/
+    struct vaccel_arg *list;
+    
+    /* current index to add the next entry */
+    int curr_idx;
+
+    /*
+    An array that holds 1 in positions
+    that memory is allocated using malloc(), 
+    so it can be freed later automatically.  
+    */
+    int *idcs_allocated_space;
+
+};
+
+/* Initializes the arg-list structure */
+struct vaccel_arg_list* vaccel_args_init(uint32_t size);
+
+/* Add a serialized argument in the list */
+int vaccel_add_serial_arg(
+    struct vaccel_arg_list* args,
+    void* buf,
+    uint32_t size
+);
+
+/* Add a non-serialized argument in the list */
+int vaccel_add_nonserial_arg(
+    struct vaccel_arg_list* args, 
+    void* buf, 
+    uint32_t argtype,
+    void* (*serializer)(void*, uint32_t*)
+);
+
+/* Define an expected argument (serialized) */
+int vaccel_expect_serial_arg(
+    struct vaccel_arg_list* args,
+    void* buf, 
+    uint32_t size
+);
+
+/* Define an expected non-serialized argument */
+int vaccel_expect_nonserial_arg(
+    struct vaccel_arg_list* args,
+    uint32_t expected_size
+);
+
+/* Extract a serialized argument out of the list */
+void* vaccel_extract_serial_arg(
+    struct vaccel_arg* args, 
+    int idx
+);
+
+/* Extract a non-serialized argument out of the list */
+void* vaccel_extract_nonserial_arg(
+    struct vaccel_arg* args, 
+    int idx, 
+    void* (*deserializer)(void*, uint32_t)
+);
+
+/* 
+Write to an expected serialized argument.
+Used inside plugin. 
+*/
+int vaccel_write_serial_arg(
+    struct vaccel_arg* args,
+    int idx,
+    void* buf
+);
+
+/* 
+Write to an expected non-serialized argument.
+Used inside plugin. 
+*/
+int vaccel_write_nonserial_arg(
+    struct vaccel_arg* args,
+    int idx,
+    void* buf,
+    void* (*serializer)(void*, uint32_t*)
+);
+
+
+/* Delete any allocated memory in the arg-list structure*/
+int vaccel_delete_args(struct vaccel_arg_list* args);
+
+#endif

--- a/src/vaccel_args.c
+++ b/src/vaccel_args.c
@@ -1,0 +1,252 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "vaccel_args.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+struct vaccel_arg_list* vaccel_args_init(uint32_t size)
+{
+    if (size == 0)
+        return NULL;
+
+    struct vaccel_arg_list* arg_list = 
+        (struct vaccel_arg_list*)malloc(sizeof(struct vaccel_arg_list));
+
+    if (!arg_list)
+        return NULL;
+
+    arg_list->list = (struct vaccel_arg*)
+        malloc(size * sizeof(struct vaccel_arg));
+
+    if (!arg_list->list) {
+        free(arg_list);
+        return NULL;
+    }
+
+    arg_list->idcs_allocated_space = (int*)
+        malloc(size * sizeof(int));
+    
+    if(!arg_list->idcs_allocated_space){
+        free(arg_list->list);
+        free(arg_list);
+        return NULL;
+    }
+
+    arg_list->size     = size;
+    arg_list->curr_idx = 0;
+
+    return arg_list;
+}
+
+int vaccel_add_serial_arg(
+    struct vaccel_arg_list* args,
+    void* buf,
+    uint32_t size)
+{
+    if (!args || !buf || !size)
+        return VACCEL_EINVAL;
+    
+    int curr_idx = args->curr_idx;
+
+    if (curr_idx >= (int)args->size)
+        return VACCEL_EINVAL;
+
+    args->list[curr_idx].size    = size;
+    args->list[curr_idx].buf     = buf;
+    args->list[curr_idx].argtype = 0;
+
+    /* The arg buffer is not allocated by malloc() */
+    args->idcs_allocated_space[curr_idx] = 0;
+
+    args->curr_idx++;
+
+    return VACCEL_OK;
+}
+
+int vaccel_add_nonserial_arg(
+    struct vaccel_arg_list* args, 
+    void* buf,
+    uint32_t argtype,
+    void* (*serializer)(void*, uint32_t*))
+{
+    if (!args || !buf || !serializer)
+        return VACCEL_EINVAL;
+
+    int curr_idx = args->curr_idx;
+
+    if (curr_idx >= (int)args->size)
+        return VACCEL_EINVAL;
+
+    uint32_t bytes; 
+    void* ser_buf = serializer(buf, &bytes);
+
+    if(!ser_buf || !bytes)
+        return VACCEL_EINVAL;
+
+    
+    args->list[curr_idx].buf     = ser_buf;
+    args->list[curr_idx].size    = bytes;
+    args->list[curr_idx].argtype = argtype;
+
+    /* The arg buffer is allocated by malloc() */
+    args->idcs_allocated_space[curr_idx] = 1;
+
+    args->curr_idx++;
+
+    return VACCEL_OK;
+}
+
+int vaccel_expect_serial_arg(
+    struct vaccel_arg_list* args, 
+    void* buf,
+    uint32_t size)
+{
+    if (!args || !buf || !size)
+        return VACCEL_EINVAL;
+    
+    int curr_idx = args->curr_idx;
+
+    if (curr_idx >= (int)args->size)
+        return VACCEL_EINVAL;
+    
+    args->list[curr_idx].buf     = buf;
+    args->list[curr_idx].size    = size;
+    args->list[curr_idx].argtype = 0;
+
+    /* The arg buffer is not allocated by malloc() */
+    args->idcs_allocated_space[curr_idx] = 0;
+
+    args->curr_idx++;
+
+    return VACCEL_OK;
+}
+
+int vaccel_expect_nonserial_arg(
+    struct vaccel_arg_list* args,
+    uint32_t expected_size)
+{
+    if (!args || !expected_size)
+        return VACCEL_EINVAL;
+     
+    int curr_idx = args->curr_idx;
+
+    if (curr_idx >= (int)args->size)
+        return VACCEL_EINVAL;
+
+    args->list[curr_idx].buf = malloc(expected_size);
+    if (!args->list[curr_idx].buf)
+        return VACCEL_ENOMEM;
+
+    args->list[curr_idx].argtype = 0;
+    args->list[curr_idx].size    = expected_size;
+    
+    /* The arg buffer is allocated by malloc() */
+    args->idcs_allocated_space[curr_idx] = 1;
+
+    args->curr_idx++;
+
+    return VACCEL_OK;
+}
+
+void* vaccel_extract_serial_arg(
+    struct vaccel_arg* args, 
+    int idx)
+{
+    if (!args || idx < 0)
+        return NULL;
+    
+    return args[idx].buf;
+}
+
+void* vaccel_extract_nonserial_arg(
+    struct vaccel_arg* args, 
+    int idx, 
+    void* (*deserializer)(void*, uint32_t))
+{
+    if (idx < 0 || !args || !deserializer)
+        return NULL;
+    
+    return deserializer(args[idx].buf, args[idx].size);
+}
+
+
+int vaccel_write_serial_arg(
+    struct vaccel_arg* args,
+    int idx,
+    void* buf
+)
+{
+    if (idx < 0 || !buf || !args) 
+        return VACCEL_EINVAL;
+
+    if (!memcpy(args[idx].buf, buf, args[idx].size))
+        return VACCEL_ENOMEM;
+
+    return VACCEL_OK;
+}
+
+int vaccel_write_nonserial_arg(
+    struct vaccel_arg* args,
+    int idx,
+    void* buf,
+    void* (*serializer)(void*, uint32_t*)
+)
+{
+    if (idx < 0 || !buf || !serializer || !args) 
+        return VACCEL_EINVAL;
+
+    uint32_t bytes;
+    void* ser_buf = serializer(buf, &bytes);
+
+    if (!ser_buf || bytes <= 0)
+        return VACCEL_EINVAL;
+
+    void *dest = memcpy(args[idx].buf, ser_buf, bytes);
+    
+    free(ser_buf);
+    
+    if (!dest)
+        return VACCEL_ENOMEM;
+
+    return VACCEL_OK;
+}
+
+int vaccel_delete_args(struct vaccel_arg_list* args)
+{
+    if (!args)
+        return VACCEL_EINVAL;
+    
+    if (!args->list || !args->size || !args->idcs_allocated_space)
+        return VACCEL_EINVAL;
+    
+    uint32_t i;
+    for (i = 0; i < args->size; i++) {
+        if (args->idcs_allocated_space[i] == 1) {
+            
+            /* memory allocated with malloc */
+            free(args->list[i].buf);
+        }
+    }
+
+    free(args->list);
+    free(args->idcs_allocated_space);
+    free(args);
+    
+    return VACCEL_OK;
+}
+
+
+

--- a/src/vaccel_args.h
+++ b/src/vaccel_args.h
@@ -12,26 +12,9 @@
  * limitations under the License.
  */
 
-#ifndef __VACCEL_GENOP_H__
-#define __VACCEL_GENOP_H__
+#ifndef __VACCEL_ARGS_H__
+#define __VACCEL_ARGS_H__
 
-#include <stdint.h>
-#include "vaccel_args.h"
+#include "include/vaccel_args.h"
 
-#ifdef __cplusplus
-extern "C" {
 #endif
-
-struct vaccel_session;
-
-
-/* Call one of the supported functions, given an op code and a set of arbitrary
- * arguments */
-int vaccel_genop(struct vaccel_session *sess, struct vaccel_arg *read,
-		int nr_read, struct vaccel_arg *write, int nr_write);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* __VACCEL_GENOP_H__ */


### PR DESCRIPTION
vaccel_args: Introduce helper functions for vAccel arguments

- genop: Add new field for argument type
- Add examples that cover ser/non-ser cases
- vaccel_args: Implement helpers
- vaccel_args: Update include files and add dir for example lib
- Move `struct vaccel_arg` definition
- Add Documentation
