### PR TITLE
meson: Re-enable tests in deb generation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,6 @@ meson.add_dist_script(
   'plugin-noop',
   opt_plugin_noop.enabled() ? 'enabled' : 'disabled',
   'examples',
-  opt_examples.enabled() ? 'enabled' : 'disabled')
-#  'tests',
-#  opt_tests.enabled() ? 'enabled' : 'disabled')
+  opt_examples.enabled() ? 'enabled' : 'disabled',
+  'tests',
+  opt_tests.enabled() ? 'enabled' : 'disabled')

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -39,6 +39,8 @@ do
 	fi                                                                          
 	c=$((c+1))                                                                  
 done
+echo "export DEB_LDFLAGS_MAINT_STRIP = -Wl,-Bsymbolic-functions\n" \
+	>> debian/rules
 echo "override_dh_auto_configure:\n\tdh_auto_configure --buildsystem=meson -- ${MESON_ARGS}" \
 	>> debian/rules
 


### PR DESCRIPTION
Remove '-Wl,-Bsymbolic-functions' from debian build's LDFLAGS as it breaks fff-based tests. Furthermore, re-enable the option to build/run tests during deb generation.