### PR TITLE
resources: Enable use of resources with dependencies

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -37,7 +37,7 @@ foreach e : examples_sources
   exe = executable(fs.stem(e),
     sources : [e, vaccel_utils_c, vaccel_headers],
     c_args : vaccel_cargs,
-    cpp_args : vaccel_cargs,
+    cpp_args : vaccel_cargs + vaccel_cppargs,
     include_directories : vaccel_includes,
     dependencies : [libvaccel_private],
     install : true)

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,7 @@ project('vaccel', 'c', 'cpp',
     '', '--no-dirty', check: false).stdout().strip())
 
 vaccel_cargs = ['-Wall','-Wextra','-Werror']
+vaccel_cppargs= ['-std=c++2b']
 plugins_cargs = vaccel_cargs + '-Wno-unused'
 
 vaccel_version = run_command('scripts/generate-version.sh',

--- a/plugins/exec/vaccel.c
+++ b/plugins/exec/vaccel.c
@@ -68,8 +68,8 @@ static int exec(struct vaccel_session *session, const char *library,
 		return VACCEL_ENOEXEC;
 
 	char *do_dlclose = getenv("VACCEL_EXEC_DLCLOSE");
-	if (do_dlclose && (strcmp(do_dlclose, "1") == 0 ||
-				strcmp(do_dlclose, "true") == 0)) {
+	if (do_dlclose &&
+	    (strcmp(do_dlclose, "1") == 0 || strcmp(do_dlclose, "true") == 0)) {
 		if (dlclose(dl)) {
 			vaccel_error("dlclose: %s", dlerror());
 			return VACCEL_EINVAL;
@@ -89,7 +89,7 @@ static int exec_with_resource(struct vaccel_session *session,
 	int ret;
 	struct vaccel_resource **deps, *resource = object->resource;
 	size_t nr_deps;
-	struct vaccel_file *file =  &object->file;
+	struct vaccel_file *file = &object->file;
 	const char *library = file->path;
 	struct vaccel_arg *args;
 
@@ -109,14 +109,15 @@ static int exec_with_resource(struct vaccel_session *session,
 		struct vaccel_shared_object *object =
 			vaccel_shared_object_from_resource(res);
 		if (!object) {
-			vaccel_error("Could not get shared_object from resource");
+			vaccel_error(
+				"Could not get shared_object from resource");
 			ret = VACCEL_EINVAL;
 			goto free;
 		}
 		const char *fpath = object->file.path;
 
 		vaccel_debug("[exec_with_resource] dep library: %s", fpath);
-		ddl[i] = dlopen(fpath, RTLD_NOW|RTLD_GLOBAL);
+		ddl[i] = dlopen(fpath, RTLD_NOW | RTLD_GLOBAL);
 		if (!ddl[i]) {
 			vaccel_error("dlopen: %s", dlerror());
 			ret = VACCEL_EINVAL;
@@ -145,20 +146,20 @@ static int exec_with_resource(struct vaccel_session *session,
 	for (size_t i = 0; i < nr_read; i++) {
 		vaccel_debug("[exec]: read[%d].size: %u\n", i, args[i].size);
 		vaccel_debug("[exec]: read[%d].argtype: %u\n", i,
-				args[i].argtype);
+			     args[i].argtype);
 	}
 	args = (struct vaccel_arg *)write;
 	for (size_t i = 0; i < nr_write; i++) {
 		vaccel_debug("[exec]: write[%d].size: %u\n", i, args[i].size);
 		vaccel_debug("[exec]: write[%d].argtype: %u\n", i,
-				args[i].argtype);
+			     args[i].argtype);
 	}
 
 	ret = (*fptr)(read, nr_read, write, nr_write);
 
 	char *do_dlclose = getenv("VACCEL_EXEC_DLCLOSE");
-	if (do_dlclose && (strcmp(do_dlclose, "1") == 0 ||
-				strcmp(do_dlclose, "true") == 0)) {
+	if (do_dlclose &&
+	    (strcmp(do_dlclose, "1") == 0 || strcmp(do_dlclose, "true") == 0)) {
 		if (dlclose(dl)) {
 			vaccel_error("dlclose: %s", dlerror());
 			ret = VACCEL_EINVAL;
@@ -166,7 +167,7 @@ static int exec_with_resource(struct vaccel_session *session,
 		}
 
 		for (size_t i = nr_deps; i > 0; i--) {
-			if (dlclose(ddl[i-1])) {
+			if (dlclose(ddl[i - 1])) {
 				vaccel_error("dlclose: %s", dlerror());
 				ret = VACCEL_EINVAL;
 				goto free;

--- a/plugins/exec/vaccel.c
+++ b/plugins/exec/vaccel.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <byteswap.h>
 #include <dlfcn.h>
 #include <stdio.h>
@@ -69,26 +71,54 @@ static int exec(struct vaccel_session *session, const char *library,
 }
 
 static int exec_with_resource(struct vaccel_session *session,
+<<<<<<< HEAD
 			      struct vaccel_shared_object *object,
 			      const char *fn_symbol, void *read, size_t nr_read,
 			      void *write, size_t nr_write)
+=======
+		struct vaccel_shared_object *object, const char *fn_symbol,
+		void *read, size_t nr_read, void *write, size_t nr_write)
+>>>>>>> 151ab19 (resources: Enable addition of resource dependencies)
 {
-	void *dl;
+	void *dl, **ddl;
 	int (*fptr)(void *, size_t, void *, size_t);
 	int ret;
-	struct vaccel_file *file;
+	struct vaccel_resource *resource = object->resource;
+	struct vaccel_file *file =  &object->file;
+	const char *library = file->path;
 	struct vaccel_arg *args;
 
 	vaccel_debug("Calling exec_with_resource for session %u",
+<<<<<<< HEAD
 		     session->session_id);
+=======
+			session->session_id);
+>>>>>>> 151ab19 (resources: Enable addition of resource dependencies)
 
-	file = &object->file;
-	const char *library = file->path;
+	if (resource->nr_deps) {
+		vaccel_debug("[exec_with_resource] nr_deps: %zu", resource->nr_deps);
+		ddl = malloc(sizeof(*ddl) * resource->nr_deps);
+		if (!ddl)
+			return VACCEL_ENOMEM;
+	}
+	for (size_t i = 0; i < resource->nr_deps; i++) {
+		struct vaccel_resource *res = resource->deps[i];
+		struct vaccel_shared_object *object =
+			(struct vaccel_shared_object *)res->data;
+		const char *fpath = object->file.path;
+
+		vaccel_debug("[exec_with_resource] dep library: %s", fpath);
+		ddl[i] = dlopen(fpath, RTLD_NOW|RTLD_GLOBAL);
+		if (!ddl[i]) {
+			vaccel_error("dlopen: %s", dlerror());
+			return VACCEL_EINVAL;
+		}
+	}
 
 	vaccel_debug("[exec_with_resource] library: %s", library);
 	dl = dlopen(library, RTLD_NOW);
 	if (!dl) {
-		vaccel_error("%s", dlerror());
+		vaccel_error("dlopen: %s", dlerror());
 		return VACCEL_EINVAL;
 	}
 
@@ -102,16 +132,33 @@ static int exec_with_resource(struct vaccel_session *session,
 
 	args = (struct vaccel_arg *)read;
 	for (size_t i = 0; i < nr_read; i++) {
-		vaccel_debug("[exec]: read[%d].size: %u\n", args[i].size);
-		vaccel_debug("[exec]: read[%d].argtype: %u\n", args[i].argtype);
+		vaccel_debug("[exec]: read[%d].size: %u\n", i, args[i].size);
+		vaccel_debug("[exec]: read[%d].argtype: %u\n", i, args[i].argtype);
 	}
 	args = (struct vaccel_arg *)write;
 	for (size_t i = 0; i < nr_write; i++) {
-		vaccel_debug("[exec]: write[%d].size: %u\n", args[i].size);
-		vaccel_debug("[exec]: write[%d].argtype: %u\n",
-			     args[i].argtype);
+		vaccel_debug("[exec]: write[%d].size: %u\n", i, args[i].size);
+		vaccel_debug("[exec]: write[%d].argtype: %u\n", i, args[i].argtype);
 	}
+
 	ret = (*fptr)(read, nr_read, write, nr_write);
+
+	// FIXME: Need to dlclose to free the disk resources
+	/*
+	if (dlclose(dl)) {
+		vaccel_error("dlclose: %s", dlerror());
+		return VACCEL_EINVAL;
+	}
+
+	for (size_t i = resource->nr_deps; i > 0; i--) {
+		vaccel_warn("DLClOSE[%d]", i);
+		if (dlclose(ddl[i-1])) {
+			vaccel_error("dlclose: %s", dlerror());
+			return VACCEL_EINVAL;
+		}
+	}
+	*/
+
 	if (ret)
 		return VACCEL_ENOEXEC;
 

--- a/plugins/exec/vaccel.c
+++ b/plugins/exec/vaccel.c
@@ -84,10 +84,12 @@ static int exec_with_resource(struct vaccel_session *session,
 			      const char *fn_symbol, void *read, size_t nr_read,
 			      void *write, size_t nr_write)
 {
-	void *dl, **ddl = NULL;
+	void *dl;
+	void **ddl = NULL;
 	int (*fptr)(void *, size_t, void *, size_t);
 	int ret;
-	struct vaccel_resource **deps, *resource = object->resource;
+	struct vaccel_resource **deps;
+	struct vaccel_resource *resource = object->resource;
 	size_t nr_deps;
 	struct vaccel_file *file = &object->file;
 	const char *library = file->path;
@@ -97,13 +99,15 @@ static int exec_with_resource(struct vaccel_session *session,
 		     session->session_id);
 
 	ret = vaccel_resource_get_deps(&deps, &nr_deps, resource);
+	if (ret)
+		return VACCEL_EINVAL;
+
 	if (nr_deps) {
 		vaccel_debug("[exec_with_resource] nr_deps: %zu", nr_deps);
 		ddl = malloc(sizeof(*ddl) * nr_deps);
 		if (!ddl)
 			return VACCEL_ENOMEM;
 	}
-	// FIXME: proper freeing
 	for (size_t i = 0; i < nr_deps; i++) {
 		struct vaccel_resource *res = deps[i];
 		struct vaccel_shared_object *object =

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,6 +1,6 @@
 opt_plugins = get_option('plugins')
 opt_plugin_noop = get_option('plugin-noop').enable_if(opt_tests.enabled()).enable_if(opt_plugins.enabled())
-opt_plugin_exec = get_option('plugin-exec').enable_if(opt_plugins.enabled())
+opt_plugin_exec = get_option('plugin-exec').enable_if(opt_tests.enabled()).enable_if(opt_plugins.enabled())
 opt_plugin_mbench = get_option('plugin-mbench').enable_if(opt_plugins.enabled())
 
 if opt_plugin_noop.enabled()

--- a/src/include/plugin.h
+++ b/src/include/plugin.h
@@ -83,6 +83,8 @@ struct vaccel_plugin_info {
 	int (*sess_register)(uint32_t sess_id, vaccel_id_t resource_id);
 	int (*sess_unregister)(uint32_t sess_id, vaccel_id_t resource_id);
 	int (*resource_new)(vaccel_resource_t, void *data, vaccel_id_t *id);
+	int (*resource_set_deps)(struct vaccel_resource *res,
+			struct vaccel_resource **deps, size_t nr_deps);
 	int (*resource_destroy)(vaccel_id_t id);
 };
 

--- a/src/include/plugin.h
+++ b/src/include/plugin.h
@@ -84,7 +84,7 @@ struct vaccel_plugin_info {
 	int (*sess_unregister)(uint32_t sess_id, vaccel_id_t resource_id);
 	int (*resource_new)(vaccel_resource_t, void *data, vaccel_id_t *id);
 	int (*resource_set_deps)(struct vaccel_resource *res,
-			struct vaccel_resource **deps, size_t nr_deps);
+				 struct vaccel_resource **deps, size_t nr_deps);
 	int (*resource_destroy)(vaccel_id_t id);
 };
 

--- a/src/include/resources.h
+++ b/src/include/resources.h
@@ -21,13 +21,13 @@ typedef enum {
 struct vaccel_resource;
 
 int vaccel_resource_get_deps(struct vaccel_resource ***deps, size_t *nr_deps,
-		struct vaccel_resource *res);
+			     struct vaccel_resource *res);
 int vaccel_resource_deps_to_ids(vaccel_id_t *ids, struct vaccel_resource **res,
-		size_t nr_ids);
+				size_t nr_ids);
 int vaccel_resource_deps_from_ids(struct vaccel_resource **deps,
-		vaccel_id_t *ids, size_t nr_ids);
+				  vaccel_id_t *ids, size_t nr_ids);
 int vaccel_resource_set_deps_from_ids(struct vaccel_resource *res,
-		vaccel_id_t *ids, size_t nr_ids);
+				      vaccel_id_t *ids, size_t nr_ids);
 
 #ifdef __cplusplus
 }

--- a/src/include/resources.h
+++ b/src/include/resources.h
@@ -2,12 +2,10 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <stdatomic.h>
+#include <stddef.h>
 
 #include "error.h"
 #include "vaccel_id.h"
-#include "list.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,34 +18,10 @@ typedef enum {
 	VACCEL_RES_MAX
 } vaccel_resource_t;
 
-struct vaccel_resource {
-	/* resource id */
-	vaccel_id_t id;
+struct vaccel_resource;
 
-	/* type of the resource */
-	vaccel_resource_t type;
-
-	/* type-specific data of the resource */
-	void *data;
-
-	/* type-specific destructor */
-	int (*cleanup_resource)(void *data);
-
-	/* An entry to add this resource in a list */
-	list_entry_t entry;
-
-	/* Reference counter representing the number of sessions
-	 * to which this resource is registered to. */
-	atomic_uint refcount;
-
-	/* rundir for this resource if it needs it. It can be empty (NULL) */
-	char *rundir;
-
-	struct vaccel_resource **deps;
-
-	size_t nr_deps;
-};
-
+int vaccel_resource_get_deps(struct vaccel_resource ***deps, size_t *nr_deps,
+		struct vaccel_resource *res);
 int vaccel_resource_deps_to_ids(vaccel_id_t *ids, struct vaccel_resource **res,
 		size_t nr_ids);
 int vaccel_resource_deps_from_ids(struct vaccel_resource **deps,

--- a/src/include/resources.h
+++ b/src/include/resources.h
@@ -22,8 +22,8 @@ struct vaccel_resource;
 
 int vaccel_resource_get_deps(struct vaccel_resource ***deps, size_t *nr_deps,
 			     struct vaccel_resource *res);
-int vaccel_resource_deps_to_ids(vaccel_id_t *ids, struct vaccel_resource **res,
-				size_t nr_ids);
+int vaccel_resource_deps_to_ids(vaccel_id_t *ids, struct vaccel_resource **deps,
+				size_t nr_deps);
 int vaccel_resource_deps_from_ids(struct vaccel_resource **deps,
 				  vaccel_id_t *ids, size_t nr_ids);
 int vaccel_resource_set_deps_from_ids(struct vaccel_resource *res,

--- a/src/include/resources/shared_object.h
+++ b/src/include/resources/shared_object.h
@@ -21,6 +21,10 @@ struct vaccel_shared_object {
 	/* The protobuf file of the shared object */
 	struct vaccel_file file;
 
+	struct vaccel_shared_object *deps;
+
+	size_t nr_deps;
+
 	/* Plugin specific data */
 	void *plugin_data;
 };
@@ -38,6 +42,10 @@ vaccel_shared_object_get_id(const struct vaccel_shared_object *object);
 
 const uint8_t *vaccel_shared_object_get(struct vaccel_shared_object *object,
 					size_t *len);
+
+int vaccel_shared_object_new_with_deps(struct vaccel_shared_object *object,
+		const char *path, const char *dep_paths[], size_t nr_deps
+);
 
 #ifdef __cplusplus
 }

--- a/src/include/resources/shared_object.h
+++ b/src/include/resources/shared_object.h
@@ -47,6 +47,9 @@ int vaccel_shared_object_new_with_deps(struct vaccel_shared_object *object,
 		const char *path, const char *dep_paths[], size_t nr_deps
 );
 
+struct vaccel_shared_object *vaccel_shared_object_from_resource(
+		struct vaccel_resource *resource);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/resources/shared_object.h
+++ b/src/include/resources/shared_object.h
@@ -44,11 +44,11 @@ const uint8_t *vaccel_shared_object_get(struct vaccel_shared_object *object,
 					size_t *len);
 
 int vaccel_shared_object_new_with_deps(struct vaccel_shared_object *object,
-		const char *path, const char *dep_paths[], size_t nr_deps
-);
+				       const char *path,
+				       const char *dep_paths[], size_t nr_deps);
 
-struct vaccel_shared_object *vaccel_shared_object_from_resource(
-		struct vaccel_resource *resource);
+struct vaccel_shared_object *
+vaccel_shared_object_from_resource(struct vaccel_resource *resource);
 
 #ifdef __cplusplus
 }

--- a/src/include/vaccel_args.h
+++ b/src/include/vaccel_args.h
@@ -77,7 +77,7 @@ int vaccel_write_nonserial_arg(struct vaccel_arg *args, int idx, void *buf,
 			       void *(*serializer)(void *, uint32_t *));
 
 /* Delete any allocated memory in the arg-list structure*/
-int vaccel_delete_args(struct vaccel_arg_list* args);
+int vaccel_delete_args(struct vaccel_arg_list *args);
 
 #ifdef __cplusplus
 }

--- a/src/include/vaccel_args.h
+++ b/src/include/vaccel_args.h
@@ -6,6 +6,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct vaccel_arg {
 	uint32_t argtype;
 
@@ -73,4 +77,8 @@ int vaccel_write_nonserial_arg(struct vaccel_arg *args, int idx, void *buf,
 			       void *(*serializer)(void *, uint32_t *));
 
 /* Delete any allocated memory in the arg-list structure*/
-int vaccel_delete_args(struct vaccel_arg_list *args);
+int vaccel_delete_args(struct vaccel_arg_list* args);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ops/exec.c
+++ b/src/ops/exec.c
@@ -123,8 +123,8 @@ int vaccel_exec_with_res_unpack(struct vaccel_session *sess,
 	char *fn_symbol = (char *)read[1].buf;
 
 	/* Pass on the rest of the read and all write arguments */
-	return vaccel_exec_with_resource (sess, object, fn_symbol, &read[2],
-			nr_read - 2, write, nr_write);
+	return vaccel_exec_with_resource(sess, object, fn_symbol, &read[2],
+					 nr_read - 2, write, nr_write);
 }
 
 __attribute__((constructor)) static void vaccel_ops_init(void)

--- a/src/ops/exec.c
+++ b/src/ops/exec.c
@@ -113,18 +113,18 @@ int vaccel_exec_with_res_unpack(struct vaccel_session *sess,
 		vaccel_error("cannot find resource: %d", ret);
 		return ret;
 	}
+
 	object = (struct vaccel_shared_object *)resource->data;
 	if (!object) {
 		vaccel_error("resource is empty..");
 		return VACCEL_EINVAL;
 	}
 
-	char *library = object->file.path;
 	char *fn_symbol = (char *)read[1].buf;
 
 	/* Pass on the rest of the read and all write arguments */
-	return vaccel_exec(sess, library, fn_symbol, &read[2], nr_read - 2,
-			   write, nr_write);
+	return vaccel_exec_with_resource (sess, object, fn_symbol, &read[2],
+			nr_read - 2, write, nr_write);
 }
 
 __attribute__((constructor)) static void vaccel_ops_init(void)

--- a/src/resources.c
+++ b/src/resources.c
@@ -111,8 +111,6 @@ int resource_get_by_id(struct vaccel_resource **resource, vaccel_id_t id)
 		}
 	}
 
-	if (*resource != NULL)
-		return VACCEL_OK;
 	return VACCEL_EINVAL;
 }
 

--- a/src/resources.c
+++ b/src/resources.c
@@ -135,6 +135,18 @@ int resource_set_deps(struct vaccel_resource *res,
 	return VACCEL_OK;
 }
 
+int vaccel_resource_get_deps(struct vaccel_resource ***deps, size_t *nr_deps,
+		struct vaccel_resource *res)
+{
+	if  (!res)
+		return VACCEL_EINVAL;
+
+	*deps = res->deps;
+	*nr_deps = res->nr_deps;
+
+	return VACCEL_OK;
+}
+
 int vaccel_resource_deps_to_ids(vaccel_id_t *ids, struct vaccel_resource **deps,
 		size_t nr_deps)
 {

--- a/src/resources.c
+++ b/src/resources.c
@@ -117,9 +117,9 @@ int resource_get_by_id(struct vaccel_resource **resource, vaccel_id_t id)
 }
 
 int resource_set_deps(struct vaccel_resource *res,
-		struct vaccel_resource **deps, size_t nr_deps)
+		      struct vaccel_resource **deps, size_t nr_deps)
 {
-	if  (!res || !deps || !nr_deps)
+	if (!res || !deps || !nr_deps)
 		return VACCEL_EINVAL;
 
 	struct vaccel_plugin *virtio = get_virtio_plugin();
@@ -136,9 +136,9 @@ int resource_set_deps(struct vaccel_resource *res,
 }
 
 int vaccel_resource_get_deps(struct vaccel_resource ***deps, size_t *nr_deps,
-		struct vaccel_resource *res)
+			     struct vaccel_resource *res)
 {
-	if  (!deps || !nr_deps || !res)
+	if (!deps || !nr_deps || !res)
 		return VACCEL_EINVAL;
 
 	*deps = res->deps;
@@ -148,12 +148,12 @@ int vaccel_resource_get_deps(struct vaccel_resource ***deps, size_t *nr_deps,
 }
 
 int vaccel_resource_deps_to_ids(vaccel_id_t *ids, struct vaccel_resource **deps,
-		size_t nr_deps)
+				size_t nr_deps)
 {
 	if (!ids || !deps || !nr_deps)
 		return VACCEL_EINVAL;
 
-	for (size_t i = 0; i <  nr_deps; i++) {
+	for (size_t i = 0; i < nr_deps; i++) {
 		ids[i] = deps[i]->id;
 	}
 
@@ -161,7 +161,7 @@ int vaccel_resource_deps_to_ids(vaccel_id_t *ids, struct vaccel_resource **deps,
 }
 
 int vaccel_resource_deps_from_ids(struct vaccel_resource **deps,
-		vaccel_id_t *ids, size_t nr_ids)
+				  vaccel_id_t *ids, size_t nr_ids)
 {
 	if (!deps || !ids || !nr_ids)
 		return VACCEL_EINVAL;
@@ -178,7 +178,7 @@ int vaccel_resource_deps_from_ids(struct vaccel_resource **deps,
 }
 
 int vaccel_resource_set_deps_from_ids(struct vaccel_resource *res,
-		vaccel_id_t *ids, size_t nr_ids)
+				      vaccel_id_t *ids, size_t nr_ids)
 {
 	if (!res || !ids || !nr_ids)
 		return VACCEL_EINVAL;
@@ -247,9 +247,9 @@ int resource_destroy(struct vaccel_resource *res)
 		free(res->rundir);
 	}
 
-	if (res->deps || res->nr_deps) 
+	if (res->deps || res->nr_deps)
 		vaccel_warn("Resource %lld has deps that will not be destroyed",
-				res->id);
+			    res->id);
 
 	return VACCEL_OK;
 }

--- a/src/resources.c
+++ b/src/resources.c
@@ -119,7 +119,7 @@ int resource_get_by_id(struct vaccel_resource **resource, vaccel_id_t id)
 int resource_set_deps(struct vaccel_resource *res,
 		struct vaccel_resource **deps, size_t nr_deps)
 {
-	if  (!deps || !nr_deps)
+	if  (!res || !deps || !nr_deps)
 		return VACCEL_EINVAL;
 
 	struct vaccel_plugin *virtio = get_virtio_plugin();
@@ -138,7 +138,7 @@ int resource_set_deps(struct vaccel_resource *res,
 int vaccel_resource_get_deps(struct vaccel_resource ***deps, size_t *nr_deps,
 		struct vaccel_resource *res)
 {
-	if  (!res)
+	if  (!deps || !nr_deps || !res)
 		return VACCEL_EINVAL;
 
 	*deps = res->deps;
@@ -200,6 +200,17 @@ int vaccel_resource_set_deps_from_ids(struct vaccel_resource *res,
 	return VACCEL_OK;
 }
 
+int resource_unset_deps(struct vaccel_resource *res)
+{
+	if (!res)
+		return VACCEL_EINVAL;
+
+	res->deps = NULL;
+	res->nr_deps = 0;
+
+	return VACCEL_OK;
+}
+
 int resource_destroy(struct vaccel_resource *res)
 {
 	if (!initialized)
@@ -236,15 +247,9 @@ int resource_destroy(struct vaccel_resource *res)
 		free(res->rundir);
 	}
 
-	/*
-	for (size_t i = 0; i < res->nr_deps; i++) {
-		int ret = resource_destroy(res->deps[i]);
-		if (ret)
-			vaccel_warn("Cannot destroy used resource %lld", res->deps[i]->id);
-	}
-	res->deps = NULL;
-	res->nr_deps = 0;
-	*/
+	if (res->deps || res->nr_deps) 
+		vaccel_warn("Resource %lld has deps that will not be destroyed",
+				res->id);
 
 	return VACCEL_OK;
 }

--- a/src/resources.h
+++ b/src/resources.h
@@ -8,40 +8,18 @@
 #include <stdatomic.h>
 #include <stdint.h>
 
-struct vaccel_resource {
-	/* resource id */
-	vaccel_id_t id;
-
-	/* type of the resource */
-	vaccel_resource_t type;
-
-	/* type-specific data of the resource */
-	void *data;
-
-	/* type-specific destructor */
-	int (*cleanup_resource)(void *data);
-
-	/* An entry to add this resource in a list */
-	list_entry_t entry;
-
-	/* Reference counter representing the number of sessions
-	 * to which this resource is registered to. */
-	atomic_uint refcount;
-
-	/* rundir for this resource if it needs it. It can be empty (NULL) */
-	char *rundir;
-};
-
 int resources_bootstrap(void);
 int resources_cleanup(void);
-int resource_new(struct vaccel_resource *res, vaccel_resource_t type,
-		 void *data, int (*cleanup_resource)(void *));
+int resource_new(struct vaccel_resource *res, vaccel_resource_t type, void *data,
+		int (*cleanup_resource)(void *));
 int resource_get_by_id(struct vaccel_resource **resource, vaccel_id_t id);
 int resource_destroy(struct vaccel_resource *res);
 void resource_refcount_inc(struct vaccel_resource *res);
 void resource_refcount_dec(struct vaccel_resource *res);
 int resource_create_rundir(struct vaccel_resource *res);
 int resource_destroy_rundir(struct vaccel_resource *res);
+int resource_set_deps(struct vaccel_resource *res,
+		struct vaccel_resource **deps, size_t nr_deps);
 
 /* Helper macros for iterating lists of containers */
 #define for_each_vaccel_resource(iter, list) \

--- a/src/resources.h
+++ b/src/resources.h
@@ -38,11 +38,11 @@ struct vaccel_resource {
 
 int resources_bootstrap(void);
 int resources_cleanup(void);
-int resource_new(struct vaccel_resource *res, vaccel_resource_t type, void *data,
-		int (*cleanup_resource)(void *));
+int resource_new(struct vaccel_resource *res, vaccel_resource_t type,
+		 void *data, int (*cleanup_resource)(void *));
 int resource_get_by_id(struct vaccel_resource **resource, vaccel_id_t id);
 int resource_set_deps(struct vaccel_resource *res,
-		struct vaccel_resource **deps, size_t nr_deps);
+		      struct vaccel_resource **deps, size_t nr_deps);
 int resource_unset_deps(struct vaccel_resource *res);
 int resource_destroy(struct vaccel_resource *res);
 void resource_refcount_inc(struct vaccel_resource *res);

--- a/src/resources.h
+++ b/src/resources.h
@@ -41,13 +41,14 @@ int resources_cleanup(void);
 int resource_new(struct vaccel_resource *res, vaccel_resource_t type, void *data,
 		int (*cleanup_resource)(void *));
 int resource_get_by_id(struct vaccel_resource **resource, vaccel_id_t id);
+int resource_set_deps(struct vaccel_resource *res,
+		struct vaccel_resource **deps, size_t nr_deps);
+int resource_unset_deps(struct vaccel_resource *res);
 int resource_destroy(struct vaccel_resource *res);
 void resource_refcount_inc(struct vaccel_resource *res);
 void resource_refcount_dec(struct vaccel_resource *res);
 int resource_create_rundir(struct vaccel_resource *res);
 int resource_destroy_rundir(struct vaccel_resource *res);
-int resource_set_deps(struct vaccel_resource *res,
-		struct vaccel_resource **deps, size_t nr_deps);
 
 /* Helper macros for iterating lists of containers */
 #define for_each_vaccel_resource(iter, list) \

--- a/src/resources.h
+++ b/src/resources.h
@@ -8,6 +8,34 @@
 #include <stdatomic.h>
 #include <stdint.h>
 
+struct vaccel_resource {
+	/* resource id */
+	vaccel_id_t id;
+
+	/* type of the resource */
+	vaccel_resource_t type;
+
+	/* type-specific data of the resource */
+	void *data;
+
+	/* type-specific destructor */
+	int (*cleanup_resource)(void *data);
+
+	/* An entry to add this resource in a list */
+	list_entry_t entry;
+
+	/* Reference counter representing the number of sessions
+	 * to which this resource is registered to. */
+	atomic_uint refcount;
+
+	/* rundir for this resource if it needs it. It can be empty (NULL) */
+	char *rundir;
+
+	struct vaccel_resource **deps;
+
+	size_t nr_deps;
+};
+
 int resources_bootstrap(void);
 int resources_cleanup(void);
 int resource_new(struct vaccel_resource *res, vaccel_resource_t type, void *data,

--- a/src/resources/file.c
+++ b/src/resources/file.c
@@ -209,7 +209,7 @@ int vaccel_file_destroy(struct vaccel_file *file)
 	if (file->path_owned) {
 		vaccel_debug("Removing file %s", file->path);
 		if (remove(file->path))
-			vaccel_warn("Could not remove file from rundir: %s",
+			vaccel_warn("Could not remove file %s from rundir: %s",
 				    file->path, strerror(errno));
 	}
 

--- a/src/resources/file.c
+++ b/src/resources/file.c
@@ -115,7 +115,7 @@ int vaccel_file_persist(struct vaccel_file *file, const char *dir,
 	}
 
 	if (fwrite(file->data, sizeof(char), file->size, fp) != file->size) {
-		vaccel_error("Could not persist file %s", file->path);
+		vaccel_error("Could not persist file %s: %s", file->path, strerror(errno));
 		ret = VACCEL_EIO;
 		goto remove_file;
 	}
@@ -209,7 +209,7 @@ int vaccel_file_destroy(struct vaccel_file *file)
 		vaccel_debug("Removing file %s", file->path);
 		if (remove(file->path))
 			vaccel_warn("Could not remove file from rundir: %s",
-				    file->path);
+					file->path, strerror(errno));
 	}
 
 	free(file->path);

--- a/src/resources/file.c
+++ b/src/resources/file.c
@@ -115,7 +115,8 @@ int vaccel_file_persist(struct vaccel_file *file, const char *dir,
 	}
 
 	if (fwrite(file->data, sizeof(char), file->size, fp) != file->size) {
-		vaccel_error("Could not persist file %s: %s", file->path, strerror(errno));
+		vaccel_error("Could not persist file %s: %s", file->path,
+			     strerror(errno));
 		ret = VACCEL_EIO;
 		goto remove_file;
 	}
@@ -209,7 +210,7 @@ int vaccel_file_destroy(struct vaccel_file *file)
 		vaccel_debug("Removing file %s", file->path);
 		if (remove(file->path))
 			vaccel_warn("Could not remove file from rundir: %s",
-					file->path, strerror(errno));
+				    file->path, strerror(errno));
 	}
 
 	free(file->path);

--- a/src/resources/shared_object.c
+++ b/src/resources/shared_object.c
@@ -53,7 +53,8 @@ free_resource:
 }
 
 int vaccel_shared_object_new_with_deps(struct vaccel_shared_object *object,
-		const char *path, const char *dep_paths[], size_t nr_deps)
+				       const char *path,
+				       const char *dep_paths[], size_t nr_deps)
 {
 	if (!dep_paths || !nr_deps)
 		return VACCEL_EINVAL;
@@ -67,7 +68,7 @@ int vaccel_shared_object_new_with_deps(struct vaccel_shared_object *object,
 		goto free_resource;
 
 	ret = resource_new(res, VACCEL_RES_SHARED_OBJ, (void *)object,
-			shared_object_destructor);
+			   shared_object_destructor);
 	if (ret)
 		goto destroy_file;
 
@@ -85,22 +86,22 @@ int vaccel_shared_object_new_with_deps(struct vaccel_shared_object *object,
 		int ret = vaccel_file_new(&deps[i].file, dep_paths[i]);
 		if (ret) {
 			vaccel_error("file_new: %s", dep_paths[i]);
-			ret =  VACCEL_ENOMEM;
+			ret = VACCEL_ENOMEM;
 			goto free_deps_res;
 		}
 
 		struct vaccel_resource *dep_res = malloc(sizeof(*res));
 		if (!dep_res) {
-			ret =  VACCEL_ENOMEM;
+			ret = VACCEL_ENOMEM;
 			goto free_deps_res;
 		}
 		deps_res[i] = dep_res;
 
 		ret = resource_new(dep_res, VACCEL_RES_SHARED_OBJ,
-				(void *)&deps[i], shared_object_destructor);
+				   (void *)&deps[i], shared_object_destructor);
 		if (ret) {
 			vaccel_error("resource_new: %s", dep_paths[i]);
-			ret =  VACCEL_ENOMEM;
+			ret = VACCEL_ENOMEM;
 			goto free_deps_res;
 		}
 
@@ -204,7 +205,7 @@ int vaccel_shared_object_destroy(struct vaccel_shared_object *object)
 	// Do not explicitly cleanup deps created from buffer when on host
 	if (!resource->rundir) {
 		vaccel_debug("Destroying resource deps: %zu",
-				resource->nr_deps);
+			     resource->nr_deps);
 		for (size_t i = 0; i < resource->nr_deps; i++) {
 			struct vaccel_resource *res = resource->deps[i];
 			vaccel_debug("Destroying dep resource %lld", res->id);
@@ -248,8 +249,8 @@ vaccel_shared_object_get_id(const struct vaccel_shared_object *object)
 	return object->resource->id;
 }
 
-struct vaccel_shared_object *vaccel_shared_object_from_resource(
-		struct vaccel_resource *resource)
+struct vaccel_shared_object *
+vaccel_shared_object_from_resource(struct vaccel_resource *resource)
 {
 	if (!resource)
 		return NULL;

--- a/src/resources/shared_object.c
+++ b/src/resources/shared_object.c
@@ -220,3 +220,12 @@ vaccel_shared_object_get_id(const struct vaccel_shared_object *object)
 
 	return object->resource->id;
 }
+
+struct vaccel_shared_object *vaccel_shared_object_from_resource(
+		struct vaccel_resource *resource)
+{
+	if (!resource)
+		return NULL;
+
+	return resource->data;
+}

--- a/src/resources/shared_object.c
+++ b/src/resources/shared_object.c
@@ -201,13 +201,6 @@ int vaccel_shared_object_destroy(struct vaccel_shared_object *object)
 
 	struct vaccel_resource *resource = object->resource;
 
-	/* This will destroy the underlying resource and call our
-	 * destructor callback */
-	vaccel_debug("Destroying resource %lld", resource->id);
-	int ret = resource_destroy(resource);
-	if (ret)
-		vaccel_warn("Could not destroy resource");
-
 	// Do not explicitly cleanup deps created from buffer when on host
 	if (!resource->rundir) {
 		vaccel_debug("Destroying resource deps: %zu",
@@ -222,7 +215,24 @@ int vaccel_shared_object_destroy(struct vaccel_shared_object *object)
 
 			free(res);
 		}
+
+		free(resource->deps);
+
+		int ret = resource_unset_deps(resource);
+		if (ret)
+			vaccel_warn("Could not unset resource deps");
 	}
+
+	/* This will destroy the underlying resource and call our
+	 * destructor callback */
+	vaccel_debug("Destroying resource %lld", resource->id);
+	int ret = resource_unset_deps(resource);
+	if (ret)
+		vaccel_warn("Could not unset resource deps");
+
+	ret = resource_destroy(resource);
+	if (ret)
+		vaccel_warn("Could not destroy resource");
 
 	free(resource);
 

--- a/src/resources/shared_object.c
+++ b/src/resources/shared_object.c
@@ -83,7 +83,7 @@ int vaccel_shared_object_new_with_deps(struct vaccel_shared_object *object,
 		deps[i].resource = NULL;
 	}
 	for (size_t i = 0; i < nr_deps; i++) {
-		int ret = vaccel_file_new(&deps[i].file, dep_paths[i]);
+		ret = vaccel_file_new(&deps[i].file, dep_paths[i]);
 		if (ret) {
 			vaccel_error("file_new: %s", dep_paths[i]);
 			ret = VACCEL_ENOMEM;
@@ -121,10 +121,12 @@ free_deps_res:
 			int r = vaccel_shared_object_destroy(&deps[i]);
 			if (r)
 				vaccel_warn("Could not destroy shared object");
-		} else if (deps_res[i]) {
+		}
+		if (deps_res[i]) {
 			free(deps_res[i]);
 		}
 	}
+	free(deps_res);
 free_deps:
 	free(deps);
 destroy_file:

--- a/test/meson.build
+++ b/test/meson.build
@@ -30,11 +30,13 @@ tests_args = [
 ]
 
 tests_env = [
-  'VACCEL_BACKENDS=' + libvaccel_noop.full_path(),
   'VACCEL_DEBUG_LEVEL=4',
 ]
 
-foreach t : tests_core_sources + tests_api_sources
+tests_env_noop = 'VACCEL_BACKENDS=' + libvaccel_noop.full_path()
+tests_env_exec = 'VACCEL_BACKENDS=' + libvaccel_exec.full_path()
+
+foreach t : tests_core_sources
   name = fs.stem(t)
   exe = executable(name,
     sources : t,
@@ -45,6 +47,29 @@ foreach t : tests_core_sources + tests_api_sources
     install : false)
 
   test(name, exe, args : tests_args, env : tests_env, is_parallel : false)
+endforeach
+
+foreach t : tests_api_sources
+  name = fs.stem(t)
+  exe = executable(name,
+    sources : t,
+    cpp_args : vaccel_cargs + '-std=c++2b',
+    include_directories : [tests_includes, vaccel_src_includes],
+    dependencies : libvaccel_private,
+    link_with : libtests_main,
+    install : false)
+
+  test(name + '+noop', exe,
+    args : tests_args,
+    env : tests_env + tests_env_noop,
+    is_parallel : false)
+
+  if name.contains('exec')
+    test(name + '+exec', exe,
+      args : tests_args,
+      env : tests_env + tests_env_exec,
+      is_parallel : false)
+  endif
 endforeach
 
 gcovr_cfg = '''

--- a/test/unit/test_resource.cpp
+++ b/test/unit/test_resource.cpp
@@ -204,7 +204,10 @@ TEST_CASE("find_resource_by_id", "[Resources]")
 TEST_CASE("with_deps", "[Resources]")
 {
 	int ret;
-	struct vaccel_resource test_res, test_dep_1, test_dep_2, **test_deps_g;
+	struct vaccel_resource test_res;
+	struct vaccel_resource test_dep_1;
+	struct vaccel_resource test_dep_2;
+	struct vaccel_resource **test_deps_g;
 	struct vaccel_resource *test_deps[2] = { &test_dep_1, &test_dep_2 };
 	size_t nr_deps;
 	vaccel_resource_t test_type = VACCEL_RES_SHARED_OBJ;
@@ -263,41 +266,42 @@ TEST_CASE("with_deps", "[Resources]")
 
 	SECTION("null_values")
 	{
-		ret = resource_set_deps(&test_res, NULL, 2);
+		ret = resource_set_deps(&test_res, nullptr, 2);
 		REQUIRE(ret == VACCEL_EINVAL);
 
 		ret = resource_set_deps(&test_res, test_deps, 0);
 		REQUIRE(ret == VACCEL_EINVAL);
 
-		ret = resource_set_deps(NULL, test_deps, 2);
+		ret = resource_set_deps(nullptr, test_deps, 2);
 		REQUIRE(ret == VACCEL_EINVAL);
 
-		ret = vaccel_resource_get_deps(NULL, &nr_deps, &test_res);
+		ret = vaccel_resource_get_deps(nullptr, &nr_deps, &test_res);
 		REQUIRE(ret == VACCEL_EINVAL);
 
-		ret = vaccel_resource_get_deps(&test_deps_g, NULL, &test_res);
+		ret = vaccel_resource_get_deps(&test_deps_g, nullptr,
+					       &test_res);
 		REQUIRE(ret == VACCEL_EINVAL);
 
-		ret = vaccel_resource_get_deps(&test_deps_g, &nr_deps, NULL);
+		ret = vaccel_resource_get_deps(&test_deps_g, &nr_deps, nullptr);
 		REQUIRE(ret == VACCEL_EINVAL);
 
-		ret = resource_unset_deps(NULL);
+		ret = resource_unset_deps(nullptr);
 		REQUIRE(ret == VACCEL_EINVAL);
 
 		vaccel_id_t dep_ids[2];
-		ret = vaccel_resource_deps_to_ids(NULL, test_deps, 2);
+		ret = vaccel_resource_deps_to_ids(nullptr, test_deps, 2);
 		REQUIRE(ret == VACCEL_EINVAL);
 
-		ret = vaccel_resource_deps_to_ids(dep_ids, NULL, 2);
+		ret = vaccel_resource_deps_to_ids(dep_ids, nullptr, 2);
 		REQUIRE(ret == VACCEL_EINVAL);
 
 		ret = vaccel_resource_deps_to_ids(dep_ids, test_deps, 0);
 		REQUIRE(ret == VACCEL_EINVAL);
 
-		ret = vaccel_resource_set_deps_from_ids(NULL, dep_ids, 2);
+		ret = vaccel_resource_set_deps_from_ids(nullptr, dep_ids, 2);
 		REQUIRE(ret == VACCEL_EINVAL);
 
-		ret = vaccel_resource_set_deps_from_ids(&test_res, NULL, 2);
+		ret = vaccel_resource_set_deps_from_ids(&test_res, nullptr, 2);
 		REQUIRE(ret == VACCEL_EINVAL);
 
 		ret = vaccel_resource_set_deps_from_ids(&test_res, dep_ids, 0);


### PR DESCRIPTION
Some resources (ie. shared libraries in exec_with_res) depend on other resources that need to be available to a plugin. Implement the required functionality to be able to create and use resources with dependencies:
- Add array of dependencies to resource struct
- Implement functions to get/set resource dependencies both from vaccelrt and virtio plugins
- Add shared object dependency functionality based on the resource dependency implementation
- Support shared objects with dependencies in exec_with_res