### PR TITLE
ci(typos): Ignore third-party headers in tests

### DIFF
--- a/.github/linters/typos.toml
+++ b/.github/linters/typos.toml
@@ -4,4 +4,9 @@ ser = "ser"
 nd = "nd"
 
 [files]
-extend-exclude = ["subprojects/*", "third-party/*"]
+extend-exclude = [
+  "subprojects/*",
+  "third-party/*",
+  "test/catch2/*",
+  "test/fff/*"
+]


### PR DESCRIPTION
Ignore 'test/catch2' and 'test/fff' when spell checking as they contain third-party headers