### PR TITLE
fix: Remove duplicate code

### DIFF
--- a/src/resources/shared_object.c
+++ b/src/resources/shared_object.c
@@ -220,10 +220,6 @@ int vaccel_shared_object_destroy(struct vaccel_shared_object *object)
 		}
 
 		free(resource->deps);
-
-		int ret = resource_unset_deps(resource);
-		if (ret)
-			vaccel_warn("Could not unset resource deps");
 	}
 
 	/* This will destroy the underlying resource and call our


### PR DESCRIPTION
The part of `vaccel_shared_object_destroy()` which unsets the dependencies of the `vaccel_resource` was repeated. Therefore I remove the first one. 